### PR TITLE
Clean up files relating to monitoring view

### DIFF
--- a/src/components/PressureDisplay.tsx
+++ b/src/components/PressureDisplay.tsx
@@ -4,12 +4,12 @@ import { BarChart, Grid, YAxis } from 'react-native-svg-charts';
 import MetricDisplay from './MetricDisplay';
 import Colors from '../constants/Colors';
 
-export default function PeepPressure(props: any) {
+export default function PressureDisplay({ measuredPressure, peep, pip }: any) {
   return (
     <View style={{ color: Colors.Borders, height: '100%' }}>
       {/* <Text style={{ color: "grey", alignSelf: "center" }}>Peak Pressure</Text> */}
       <MetricDisplay
-        value={props.PeakPressure}
+        value={measuredPressure}
         title={'Pressure'}
         unit={'cmH2O'}></MetricDisplay>
       <View style={{}}>
@@ -31,7 +31,7 @@ export default function PeepPressure(props: any) {
             style={styles.peepgauge}
             yMin={0}
             yMax={100}
-            data={[props.PeakPressure]}
+            data={[measuredPressure]}
             svg={{ fill: Colors.BarColor }}
             animate={true}
             showGrid={true}
@@ -49,12 +49,12 @@ export default function PeepPressure(props: any) {
           }}>
           <MetricDisplay
             style={styles.peep}
-            value={props.Pip}
+            value={pip}
             title={'PIP'}
             unit={'cmH20'}></MetricDisplay>
           <MetricDisplay
             style={styles.peep}
-            value={props.Peep}
+            value={peep}
             title={'PEEP'}
             unit={'cmH20'}></MetricDisplay>
         </View>

--- a/src/constants/InitialReading.ts
+++ b/src/constants/InitialReading.ts
@@ -1,0 +1,23 @@
+import Constants from './Constants';
+
+export default {
+  peep: 5,
+  measuredPressure: 25,
+  plateauPressure: 20,
+  patientRate: 10,
+  tidalVolume: 200,
+  ieRatio: '1:2',
+  vti: 100,
+  vte: 400,
+  minuteVentilation: 100,
+  inspiratoryTime: 3,
+  expiratoryTime: 5,
+  fiO2: 21,
+  flowRate: 23,
+  PIP: 50,
+  mode: 'VCV',
+  graphPressure: new Array(Constants.GraphLength).fill(40),
+  graphVolume: new Array(Constants.GraphLength).fill(200),
+  graphFlow: new Array(Constants.GraphLength).fill(150),
+  alarms: [],
+};

--- a/src/logic/DummyDataGenerator.ts
+++ b/src/logic/DummyDataGenerator.ts
@@ -1,4 +1,3 @@
-import Alarms from '../constants/Alarms';
 import { processSerialData } from './SerialParser';
 
 export default function dummyDataGenerator(
@@ -9,32 +8,7 @@ export default function dummyDataGenerator(
   let data: string = '';
   let Counter = 0;
 
-  function getRandomValue(range: number, valueToSubtract = 0) {
-    return Math.round(Math.random() * range - valueToSubtract);
-  }
-
   function generateDummyReadings() {
-    // let readings: any = {
-    //   peep: getRandomValue(10),
-    //   peakPressure: getRandomValue(100, 100),
-    //   patientRate: getRandomValue(220),
-    //   plateauPressure: getRandomValue(20),
-    //   vte: getRandomValue(700),
-    //   inspiratoryTime: getRandomValue(3),
-    //   expiratoryTime: getRandomValue(5).toFixed(1),
-    //   oxygen: getRandomValue(100),
-    //   flow: getRandomValue(30, 10),
-    // };
-    // let patientRate = readings.patientRate;
-    // let alarms = [];
-    // if (patientRate > 150) {
-    //   alarms.push(Alarms[0]);
-    // } else if (patientRate < 150 && patientRate > 100) {
-    //   alarms.push(Alarms[2]);
-    // }
-    // readings.alarms = alarms;
-    // console.log(readings);
-    // return readings;
     let Data = new Array(49);
     if (Counter < data.length) {
       for (let i = 0; i < 49; i++) {
@@ -48,7 +22,7 @@ export default function dummyDataGenerator(
 
   function startGenerating() {
     var RNFS = require('react-native-fs');
-    RNFS.readFileAssets('sample_data.txt', 'ascii').then((result) => {
+    RNFS.readFileAssets('sample_data.txt', 'ascii').then((result: any) => {
       // console.log('GOT RESULT', result);
       data = result;
       // console.log()

--- a/src/logic/SerialParser.tsx
+++ b/src/logic/SerialParser.tsx
@@ -102,8 +102,7 @@ export const processSerialData = (
       // console.log('updateing');
       updateReadingStateFunction({
         peep: Data[26] - 30,
-        peakPressure: ((Data[10] + Data[11] * 256) * 90) / 65535 - 30,
-        // patientRate: getRandomValue(220),
+        measuredPressure: ((Data[10] + Data[11] * 256) * 90) / 65535 - 30,
         plateauPressure: getWordFloat(Data[16], Data[17], 90 / 65535, -30),
         patientRate: Data[23], //23
         tidalVolume: getWordFloat(Data[20], Data[21], 1, 0),
@@ -111,10 +110,9 @@ export const processSerialData = (
         vti: getWordFloat(Data[30], Data[31], 4000 / 65535, -2000),
         vte: getWordFloat(Data[32], Data[33], 4000 / 65535, -2000),
         minuteVentilation: getWordFloat(Data[34], Data[35], 40 / 65535, 0),
-        //ieRatio: FailedPacket + '/' + TotalPacket,
         inspiratoryTime: 1,
         expiratoryTime: 5,
-        oxygen: Data[25], //25
+        fiO2: Data[25], //25
         flow: 23,
         flowrate: 23,
         PIP: Data[40] - 30,

--- a/src/logic/useReading.tsx
+++ b/src/logic/useReading.tsx
@@ -2,8 +2,7 @@
 import React, { useState, useEffect, useContext, createContext } from 'react';
 import DummyDataGenerator from './DummyDataGenerator';
 import SerialDataHandler from './SerialDataHandler';
-import Constants from '../constants/Constants';
-import dummyDataGenerator from './DummyDataGenerator';
+import InitialReading from '../constants/InitialReading';
 
 const readingContext = createContext<any>(null);
 
@@ -26,22 +25,8 @@ export const useReading = () => {
 
 // Provider hook that creates auth object and handles state
 function useProvideReading() {
-  const [reading, setReading] = useState({
-    peep: 5,
-    peakPressure: 25,
-    // patientRate: getRandomValue(220),
-    plateauPressure: 20,
-    patientRate: 10,
-    vte: 400,
-    inspiratoryTime: 3,
-    expiratoryTime: 5,
-    oxygen: 21,
-    flow: 23,
-    graphPressure: new Array(Constants.GraphLength).fill(40),
-    graphVolume: new Array(Constants.GraphLength).fill(200),
-    graphFlow: new Array(Constants.GraphLength).fill(150),
-  });
-  // const dummyGenerator = DummyDataGenerator(setReading, 10);
+  const [reading, setReading] = useState(InitialReading);
+  // const dummyGenerator = DummyDataGenerator(setReading, 20);
   const serialDataHandler = SerialDataHandler({ baudRate: 115200 }, setReading);
 
   // Subscribe to user on mount

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useState } from 'react';
 import { Platform, StyleSheet, View, Text } from 'react-native';
-import PeepPressure from '../components/PeepPressure';
+import PressureDisplay from '../components/PressureDisplay';
 import Graphs from '../components/Graphs';
 import MetricDisplay from '../components/MetricDisplay';
 import AlarmMetricDisplay from '../components/AlarmMetricDisplay';
@@ -15,27 +15,16 @@ import Colors from '../constants/Colors';
 export default function HomeScreen(props: any) {
   const reading = useReading();
   const readingValues = reading.values;
-  // const [PeakPress, setPeakPressure] = useState(10);
-  // const [GraphPressure, setGraphPressure] = useState(new Array(2000).fill(0));
-  // const [GraphVolume, setGraphVolume] = useState(new Array(2000).fill(0));
-  // const [PatientRate, setPatientRate] = useState(0);
-  // const [ITime, setITime] = useState('1.0');
-  // const [VTe, setVTe] = useState(0);
-  // const [IERatio, setIERatio] = useState('1:2.0');
-  // const [Oxygen, setOxygen] = useState(21);
-  // const [PlateauPressure, setPlateauPressure] = useState(21);
-  const [Peep, setPeep] = useState(5);
   const ventilatorConfig = initalVentilatorConfiguration;
-  const patientRate: SetParameter = ventilatorConfig.respiratoryRate;
 
   // console.log('homescreen');
   return (
     <View style={styles.container}>
-      <View style={styles.peakpressure}>
-        <PeepPressure
-          PeakPressure={readingValues.peakPressure}
-          Peep={readingValues.peep}
-          Pip={readingValues.PIP}></PeepPressure>
+      <View style={styles.pressureDisplay}>
+        <PressureDisplay
+          measuredPressure={readingValues.measuredPressure}
+          peep={readingValues.peep}
+          pip={readingValues.PIP}></PressureDisplay>
       </View>
       {/* <View style={styles.valuesandgraphs}> */}
       <View style={styles.graphs}>
@@ -58,7 +47,7 @@ export default function HomeScreen(props: any) {
             numberOfTicks={4}
             fillColor={Colors.graphVolume}
             strokeColor={Colors.graphVolumeStrokeColor}
-            // style={{ maxheight: "50%" }}
+          // style={{ maxheight: "50%" }}
           ></Graphs>
         </View>
         <Text style={styles.graphTitle}>Flow Rate [lpm]</Text>
@@ -70,7 +59,7 @@ export default function HomeScreen(props: any) {
             numberOfTicks={4}
             fillColor={Colors.graphFlow}
             strokeColor={Colors.graphFlowStrokeColor}
-            // style={{ maxheight: "50%" }}
+          // style={{ maxheight: "50%" }}
           ></Graphs>
         </View>
       </View>
@@ -78,7 +67,7 @@ export default function HomeScreen(props: any) {
         <MetricDisplay
           style={styles.configuredvaluedisplay}
           title={'FiO2'}
-          value={readingValues.oxygen}
+          value={readingValues.fiO2}
           unit={'%'}></MetricDisplay>
         <MetricDisplay
           style={styles.configuredvaluedisplay}
@@ -87,12 +76,12 @@ export default function HomeScreen(props: any) {
           unit={'BPM'}></MetricDisplay>
         <MetricDisplay
           style={styles.configuredvaluedisplay}
-          title={'Tidal Vol'}
+          title={'Tidal Volume'}
           value={readingValues.tidalVolume}
           unit={'ml'}></MetricDisplay>
         <MetricDisplay
           style={styles.configuredvaluedisplay}
-          title={'Plateau Press.'}
+          title={'Plateau Pressure'}
           value={readingValues.plateauPressure}
           unit={''}></MetricDisplay>
 
@@ -114,12 +103,12 @@ export default function HomeScreen(props: any) {
           unit={'ml'}></MetricDisplay>
         <MetricDisplay
           style={styles.configuredvaluedisplay}
-          title={'Minute Vent'}
+          title={'Minute Ventilation'}
           value={readingValues.minuteVentilation}
           unit={'slm'}></MetricDisplay>
         <MetricDisplayString
           style={styles.configuredvaluedisplay}
-          title={'Mode'}
+          title={'Ventilation Mode'}
           value={readingValues.mode}
           unit={''}></MetricDisplayString>
       </View>
@@ -141,7 +130,7 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.GeneralBackGround,
     padding: 2,
   },
-  peakpressure: {
+  pressureDisplay: {
     flex: 1,
     height: '100%',
     backgroundColor: Colors.GeneralBackGround,


### PR DESCRIPTION
This change cleans up multiple things relating to the monitoring page view:

- `PeepPressure` component re-named to `PressureDisplay` since the component shows multiple pressure values. camel-cased values to follow JavaScript standards as well.
- `peakPressure` was actually `measuredPressure`. `peakPressure` value is currently being contained in `pip`.
- The initial reading being used in the `useReading` hook moved to a constant (`InitialReading`) for ease of importing anywhere.
- `oxygen` renamed to `fiO2` as that is the value being used everywhere else
- Changed abbreviated descriptions into full descriptions