### PR TITLE
Add status based alarms

### DIFF
--- a/src/components/ConnectionsHeader/icons.tsx
+++ b/src/components/ConnectionsHeader/icons.tsx
@@ -13,7 +13,7 @@ export const ALARMS = {
     status: 'Circuit Integrity Passing',
     icon: (status: boolean) => (
       <Octicons
-        size={FontSize.IconSize}
+        size={FontSize.iconSize}
         name="circuit-board"
         color={status ? 'red' : 'green'}
       />
@@ -23,7 +23,7 @@ export const ALARMS = {
     status: 'Battery Disconnected',
     icon: (status: boolean) => (
       <Entypo
-        size={FontSize.IconSize}
+        size={FontSize.iconSize}
         name="battery"
         color={status ? 'red' : 'green'}
       />
@@ -33,7 +33,7 @@ export const ALARMS = {
     status: 'Patient Vent Circuit Connected',
     icon: (status: boolean) => (
       <MaterialCommunityIcons
-        size={FontSize.IconSize}
+        size={FontSize.iconSize}
         name="heart-pulse"
         color={status ? 'red' : 'green'}
       />
@@ -43,7 +43,7 @@ export const ALARMS = {
     status: 'Flow Sensor Connected',
     icon: (status: boolean) => (
       <MaterialCommunityIcons
-        size={FontSize.IconSize}
+        size={FontSize.iconSize}
         name="gauge"
         color={status ? 'red' : 'green'}
       />
@@ -53,7 +53,7 @@ export const ALARMS = {
     status: 'Pressure Sensor Connected',
     icon: (status: boolean) => (
       <AntDesign
-        size={FontSize.IconSize}
+        size={FontSize.iconSize}
         name="upcircleo"
         color={status ? 'red' : 'green'}
       />
@@ -63,7 +63,7 @@ export const ALARMS = {
     status: 'Oxygen Sensor Connected',
     icon: (status: boolean) => (
       <MaterialCommunityIcons
-        size={FontSize.IconSize}
+        size={FontSize.iconSize}
         name="gas-cylinder"
         color={status ? 'red' : 'green'}
       />
@@ -76,7 +76,7 @@ export const ALARMS = {
         case true:
           return (
             <Feather
-              size={FontSize.IconSize}
+              size={FontSize.iconSize}
               name="alert-circle"
               color={'red'}
             />
@@ -84,7 +84,7 @@ export const ALARMS = {
         case false:
           return (
             <AntDesign
-              size={FontSize.IconSize}
+              size={FontSize.iconSize}
               name="checkcircleo"
               color={'green'}
             />
@@ -98,7 +98,7 @@ export const ALARMS = {
     status: 'Mechanical Integrity Intact',
     icon: (status: boolean) => (
       <FontAwesome
-        size={FontSize.IconSize}
+        size={FontSize.iconSize}
         name="gears"
         color={status ? 'red' : 'green'}
       />
@@ -111,7 +111,7 @@ export const ALARMS = {
         case true:
           return (
             <Entypo
-              size={FontSize.IconSize}
+              size={FontSize.iconSize}
               name="circle-with-cross"
               color={'red'}
             />
@@ -119,7 +119,7 @@ export const ALARMS = {
         case false:
           return (
             <MaterialIcons
-              size={FontSize.IconSize}
+              size={FontSize.iconSize}
               name="done"
               color={'green'}
             />
@@ -133,7 +133,7 @@ export const ALARMS = {
     status: 'Hrs of Operation',
     icon: (status: boolean) => (
       <Entypo
-        size={FontSize.IconSize}
+        size={FontSize.iconSize}
         name="cycle"
         color={status ? 'red' : 'green'}
       />

--- a/src/components/ConnectionsHeader/icons.tsx
+++ b/src/components/ConnectionsHeader/icons.tsx
@@ -3,13 +3,17 @@ import Octicons from 'react-native-vector-icons/Octicons';
 import Entypo from 'react-native-vector-icons/Entypo';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 import AntDesign from 'react-native-vector-icons/AntDesign';
+import Feather from 'react-native-vector-icons/Feather';
+import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
+import FontAwesome from 'react-native-vector-icons/FontAwesome';
+import FontSize from '../../constants/FontSize';
 
 export const ALARMS = {
   'Circuit Integrity Failed': {
     status: 'Circuit Integrity Passing',
     icon: (status: boolean) => (
       <Octicons
-        size={50}
+        size={FontSize.IconSize}
         name="circuit-board"
         color={status ? 'red' : 'green'}
       />
@@ -18,14 +22,18 @@ export const ALARMS = {
   'Battery in Use': {
     status: 'Battery Disconnected',
     icon: (status: boolean) => (
-      <Entypo size={50} name="battery" color={status ? 'red' : 'green'} />
+      <Entypo
+        size={FontSize.IconSize}
+        name="battery"
+        color={status ? 'red' : 'green'}
+      />
     ),
   },
   'Patient Vent Circuit Disconnected': {
     status: 'Patient Vent Circuit Connected',
     icon: (status: boolean) => (
       <MaterialCommunityIcons
-        size={50}
+        size={FontSize.IconSize}
         name="heart-pulse"
         color={status ? 'red' : 'green'}
       />
@@ -35,7 +43,7 @@ export const ALARMS = {
     status: 'Flow Sensor Connected',
     icon: (status: boolean) => (
       <MaterialCommunityIcons
-        size={50}
+        size={FontSize.IconSize}
         name="gauge"
         color={status ? 'red' : 'green'}
       />
@@ -44,15 +52,89 @@ export const ALARMS = {
   'Pressure Sensor Disconnected': {
     status: 'Pressure Sensor Connected',
     icon: (status: boolean) => (
-      <AntDesign size={50} name="upcircleo" color={status ? 'red' : 'green'} />
+      <AntDesign
+        size={FontSize.IconSize}
+        name="upcircleo"
+        color={status ? 'red' : 'green'}
+      />
     ),
   },
   'Oxygen Sensor Disconnected': {
     status: 'Oxygen Sensor Connected',
     icon: (status: boolean) => (
       <MaterialCommunityIcons
-        size={50}
+        size={FontSize.IconSize}
         name="gas-cylinder"
+        color={status ? 'red' : 'green'}
+      />
+    ),
+  },
+  'Oxygen Failure': {
+    status: 'Oxygen Intact',
+    icon: (status: boolean) => {
+      switch (status) {
+        case true:
+          return (
+            <Feather
+              size={FontSize.IconSize}
+              name="alert-circle"
+              color={'red'}
+            />
+          );
+        case false:
+          return (
+            <AntDesign
+              size={FontSize.IconSize}
+              name="checkcircleo"
+              color={'green'}
+            />
+          );
+        default:
+          return null;
+      }
+    },
+  },
+  'Mechanical Integrity Failed': {
+    status: 'Mechanical Integrity Intact',
+    icon: (status: boolean) => (
+      <FontAwesome
+        size={FontSize.IconSize}
+        name="gears"
+        color={status ? 'red' : 'green'}
+      />
+    ),
+  },
+  'Homing not Done': {
+    status: 'Homing Done',
+    icon: (status: boolean) => {
+      switch (status) {
+        case true:
+          return (
+            <Entypo
+              size={FontSize.IconSize}
+              name="circle-with-cross"
+              color={'red'}
+            />
+          );
+        case false:
+          return (
+            <MaterialIcons
+              size={FontSize.IconSize}
+              name="done"
+              color={'green'}
+            />
+          );
+        default:
+          return null;
+      }
+    },
+  },
+  '96 Hours of Operation': {
+    status: 'Hrs of Operation',
+    icon: (status: boolean) => (
+      <Entypo
+        size={FontSize.IconSize}
+        name="cycle"
         color={status ? 'red' : 'green'}
       />
     ),

--- a/src/components/ConnectionsHeader/icons.tsx
+++ b/src/components/ConnectionsHeader/icons.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import Octicons from 'react-native-vector-icons/Octicons';
+import Entypo from 'react-native-vector-icons/Entypo';
+import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
+import AntDesign from 'react-native-vector-icons/AntDesign';
+
+export const ALARMS = {
+  'Circuit Integrity Failed': {
+    status: 'Circuit Integrity Passing',
+    icon: (status: boolean) => (
+      <Octicons
+        size={50}
+        name="circuit-board"
+        color={status ? 'red' : 'green'}
+      />
+    ),
+  },
+  'Battery in Use': {
+    status: 'Battery Disconnected',
+    icon: (status: boolean) => (
+      <Entypo size={50} name="battery" color={status ? 'red' : 'green'} />
+    ),
+  },
+  'Patient Vent Circuit Disconnected': {
+    status: 'Patient Vent Circuit Connected',
+    icon: (status: boolean) => (
+      <MaterialCommunityIcons
+        size={50}
+        name="heart-pulse"
+        color={status ? 'red' : 'green'}
+      />
+    ),
+  },
+  'Flow Sensor Disconnected': {
+    status: 'Flow Sensor Connected',
+    icon: (status: boolean) => (
+      <MaterialCommunityIcons
+        size={50}
+        name="gauge"
+        color={status ? 'red' : 'green'}
+      />
+    ),
+  },
+  'Pressure Sensor Disconnected': {
+    status: 'Pressure Sensor Connected',
+    icon: (status: boolean) => (
+      <AntDesign size={50} name="upcircleo" color={status ? 'red' : 'green'} />
+    ),
+  },
+  'Oxygen Sensor Disconnected': {
+    status: 'Oxygen Sensor Connected',
+    icon: (status: boolean) => (
+      <MaterialCommunityIcons
+        size={50}
+        name="gas-cylinder"
+        color={status ? 'red' : 'green'}
+      />
+    ),
+  },
+};

--- a/src/components/ConnectionsHeader/index.tsx
+++ b/src/components/ConnectionsHeader/index.tsx
@@ -1,6 +1,24 @@
 import React from 'react';
-import { Header, ConnectionContainer } from './styled';
+import { Header, ConnectionContainer, ConnectionLabel } from './styled';
+import { useReading } from '../../logic/useReading';
+import { ALARMS } from './icons';
+
+function updateAlarmsUI(alarms: string[]) {
+  return Object.keys(ALARMS).map((warning) => {
+    let connectionStatus = alarms.includes(warning);
+
+    return (
+      <ConnectionContainer key={warning}>
+        {ALARMS[warning].icon(connectionStatus)}
+        <ConnectionLabel>
+          {connectionStatus ? warning : ALARMS[warning].status}
+        </ConnectionLabel>
+      </ConnectionContainer>
+    );
+  });
+}
 
 export const ConnectionsHeader = () => {
-  return <Header></Header>;
+  const alarms = useReading().values.alarms;
+  return <Header>{updateAlarmsUI(alarms)}</Header>;
 };

--- a/src/components/ConnectionsHeader/index.tsx
+++ b/src/components/ConnectionsHeader/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Header, ConnectionContainer, ConnectionLabel } from './styled';
 import { useReading } from '../../logic/useReading';
 import { ALARMS } from './icons';
+import FontSize from '../../constants/FontSize';
 
 function updateAlarmsUI(alarms: string[]) {
   return Object.keys(ALARMS).map((warning) => {
@@ -10,7 +11,12 @@ function updateAlarmsUI(alarms: string[]) {
     return (
       <ConnectionContainer key={warning}>
         {ALARMS[warning].icon(connectionStatus)}
-        <ConnectionLabel>
+        <ConnectionLabel
+          fontSize={
+            warning.length > 20 && ALARMS[warning].status.length > 20
+              ? FontSize.connectionLabelLongText
+              : FontSize.connectionLabelShortText
+          }>
           {connectionStatus ? warning : ALARMS[warning].status}
         </ConnectionLabel>
       </ConnectionContainer>

--- a/src/components/ConnectionsHeader/index.tsx
+++ b/src/components/ConnectionsHeader/index.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Header, ConnectionContainer } from './styled';
+
+export const ConnectionsHeader = () => {
+  return <Header></Header>;
+};

--- a/src/components/ConnectionsHeader/index.tsx
+++ b/src/components/ConnectionsHeader/index.tsx
@@ -11,12 +11,7 @@ function updateAlarmsUI(alarms: string[]) {
     return (
       <ConnectionContainer key={warning}>
         {ALARMS[warning].icon(connectionStatus)}
-        <ConnectionLabel
-          fontSize={
-            warning.length > 20 && ALARMS[warning].status.length > 20
-              ? FontSize.connectionLabelLongText
-              : FontSize.connectionLabelShortText
-          }>
+        <ConnectionLabel fontSize={FontSize.connectionLabelText}>
           {connectionStatus ? warning : ALARMS[warning].status}
         </ConnectionLabel>
       </ConnectionContainer>

--- a/src/components/ConnectionsHeader/styled.ts
+++ b/src/components/ConnectionsHeader/styled.ts
@@ -4,8 +4,6 @@ export const Header = styled.View`
   flex: 1;
   padding-top: 50px;
   padding-bottom: 30px;
-  padding-left: 10px;
-  padding-right: 10px;
   flex-direction: row;
   background-color: #354650;
   justify-content: space-evenly;
@@ -17,7 +15,6 @@ export const ConnectionContainer = styled.View`
   justify-content: center;
   align-self: center;
   flex-direction: column;
-  padding-left: 30px;
   text-align: center;
   flex: 1;
 `;

--- a/src/components/ConnectionsHeader/styled.ts
+++ b/src/components/ConnectionsHeader/styled.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components/native';
 
 export const Header = styled.View`
   flex: 1;
-  padding-top: 50px;
+  padding-top: 60px;
   padding-bottom: 30px;
   flex-direction: row;
   background-color: #354650;
@@ -19,9 +19,11 @@ export const ConnectionContainer = styled.View`
   flex: 1;
 `;
 
-export const ConnectionLabel = styled.Text`
+export const ConnectionLabel = styled.Text<{
+  fontSize: string;
+}>`
   color: white;
   text-align: center;
   width: 80%;
-  font-size: 18px;
+  font-size: ${({ fontSize }) => fontSize};
 `;

--- a/src/components/ConnectionsHeader/styled.ts
+++ b/src/components/ConnectionsHeader/styled.ts
@@ -1,0 +1,14 @@
+import styled from 'styled-components/native';
+
+export const Header = styled.View`
+  flex: 1;
+  flex-direction: row;
+  justify-content: space-evenly;
+  align-items: center;
+  background-color: blue;
+`;
+
+export const ConnectionContainer = styled.View`
+  align-items: center;
+  background-color: yellow;
+`;

--- a/src/components/ConnectionsHeader/styled.ts
+++ b/src/components/ConnectionsHeader/styled.ts
@@ -2,13 +2,29 @@ import styled from 'styled-components/native';
 
 export const Header = styled.View`
   flex: 1;
+  padding-top: 50px;
+  padding-bottom: 30px;
+  padding-left: 10px;
+  padding-right: 10px;
   flex-direction: row;
+  background-color: #354650;
   justify-content: space-evenly;
   align-items: center;
-  background-color: blue;
 `;
 
 export const ConnectionContainer = styled.View`
   align-items: center;
-  background-color: yellow;
+  justify-content: center;
+  align-self: center;
+  flex-direction: column;
+  padding-left: 30px;
+  text-align: center;
+  flex: 1;
+`;
+
+export const ConnectionLabel = styled.Text`
+  color: white;
+  text-align: center;
+  width: 80%;
+  font-size: 18px;
 `;

--- a/src/constants/FontSize.ts
+++ b/src/constants/FontSize.ts
@@ -1,5 +1,4 @@
 export default {
-  connectionLabelLongText: '15px',
-  connectionLabelShortText: '18px',
+  connectionLabelText: '15px',
   IconSize: 50,
 };

--- a/src/constants/FontSize.ts
+++ b/src/constants/FontSize.ts
@@ -1,4 +1,4 @@
 export default {
   connectionLabelText: '15px',
-  IconSize: 50,
+  iconSize: 50,
 };

--- a/src/constants/FontSize.ts
+++ b/src/constants/FontSize.ts
@@ -1,0 +1,5 @@
+export default {
+  connectionLabelLongText: '15px',
+  connectionLabelShortText: '18px',
+  IconSize: 50,
+};

--- a/src/screens/AlarmsScreen.tsx
+++ b/src/screens/AlarmsScreen.tsx
@@ -39,28 +39,28 @@ export default function AlarmsScreen() {
       }}>
       <ConnectionsHeader />
       <View style={styles.gaugeContainer}>
-        <ScrollView>
-          {metrics &&
-            metrics?.map((row, index) => {
-              return (
-                <Row key={row[index]?.name || ''}>
-                  {row.map((metricToDisplay) => {
-                    console.log(metricToDisplay);
-                    // check if type is SetParameter
-                    if (metricToDisplay.name) {
-                      return (
-                        <DetailedAlarmMetricDisplay
-                          key={metricToDisplay.name}
-                          metric={metricToDisplay}
-                        />
-                      );
-                    }
-                    return null;
-                  })}
-                </Row>
-              );
-            })}
-        </ScrollView>
+        {/* <ScrollView> */}
+        {metrics &&
+          metrics?.map((row, index) => {
+            return (
+              <Row key={row[index]?.name || ''}>
+                {row.map((metricToDisplay) => {
+                  console.log(metricToDisplay);
+                  // check if type is SetParameter
+                  if (metricToDisplay.name) {
+                    return (
+                      <DetailedAlarmMetricDisplay
+                        key={metricToDisplay.name}
+                        metric={metricToDisplay}
+                      />
+                    );
+                  }
+                  return null;
+                })}
+              </Row>
+            );
+          })}
+        {/* </ScrollView> */}
       </View>
     </View>
   );

--- a/src/screens/AlarmsScreen.tsx
+++ b/src/screens/AlarmsScreen.tsx
@@ -6,6 +6,7 @@ import { Row } from '../components/Globals/Row';
 import initalVentilatorConfiguration from '../constants/InitialVentilatorConfiguration';
 import SetParameter from '../interfaces/SetParameter';
 import { useReading } from '../logic/useReading';
+import { ConnectionsHeader } from '../components/ConnectionsHeader';
 
 export default function AlarmsScreen() {
   const reading = useReading();
@@ -32,32 +33,35 @@ export default function AlarmsScreen() {
   }, [readingValues]);
 
   return (
-    <View style={styles.gaugeContainer}>
-      <ScrollView
-        style={{
-          flexGrow: 1,
-        }}>
-        {metrics &&
-          metrics?.map((row, index) => {
-            return (
-              <Row key={row[index]?.name || ''}>
-                {row.map((metricToDisplay) => {
-                  console.log(metricToDisplay);
-                  // check if type is SetParameter
-                  if (metricToDisplay.name) {
-                    return (
-                      <DetailedAlarmMetricDisplay
-                        key={metricToDisplay.name}
-                        metric={metricToDisplay}
-                      />
-                    );
-                  }
-                  return null;
-                })}
-              </Row>
-            );
-          })}
-      </ScrollView>
+    <View
+      style={{
+        flex: 1,
+      }}>
+      <ConnectionsHeader />
+      <View style={styles.gaugeContainer}>
+        <ScrollView>
+          {metrics &&
+            metrics?.map((row, index) => {
+              return (
+                <Row key={row[index]?.name || ''}>
+                  {row.map((metricToDisplay) => {
+                    console.log(metricToDisplay);
+                    // check if type is SetParameter
+                    if (metricToDisplay.name) {
+                      return (
+                        <DetailedAlarmMetricDisplay
+                          key={metricToDisplay.name}
+                          metric={metricToDisplay}
+                        />
+                      );
+                    }
+                    return null;
+                  })}
+                </Row>
+              );
+            })}
+        </ScrollView>
+      </View>
     </View>
   );
 }
@@ -66,9 +70,7 @@ const styles = StyleSheet.create({
   gaugeContainer: {
     marginBottom: 15,
     marginTop: 15,
-    flex: 1,
-    justifyContent: 'center',
+    flex: 9,
     width: '100%',
-    alignSelf: 'center',
   },
 });


### PR DESCRIPTION
This change adds the remaining alarms which are status based (can either be true or false rather than metric based). These have been added as a separate header to show these statues on the top with green values denoting normal status and red status with icon change to show alarm status. This completes the development for the alarms tab.

Resolves: #20