### PR TITLE
Minor changes to app visuals

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -133,8 +133,8 @@ android {
         applicationId "com.openventpkventilatorapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode 31
+        versionName "0.3.1"
     }
     splits {
         abi {

--- a/src/components/PressureDisplay.tsx
+++ b/src/components/PressureDisplay.tsx
@@ -4,7 +4,12 @@ import { BarChart, Grid, YAxis } from 'react-native-svg-charts';
 import MetricDisplay from './MetricDisplay';
 import Colors from '../constants/Colors';
 
-export default function PressureDisplay({ measuredPressure, peep, pip }: any) {
+export default function PressureDisplay({
+  measuredPressure,
+  peep,
+  pip,
+  plateauPressure,
+}: any) {
   return (
     <View style={{ color: Colors.Borders, height: '100%' }}>
       {/* <Text style={{ color: "grey", alignSelf: "center" }}>Peak Pressure</Text> */}
@@ -15,7 +20,7 @@ export default function PressureDisplay({ measuredPressure, peep, pip }: any) {
       <View style={{}}>
         <View style={styles.peepgaugewithaxis}>
           <YAxis
-            data={[0, 100]}
+            data={[0, 80]}
             contentInset={{ top: 4, bottom: 3 }}
             svg={{
               fill: Colors.TextColor,
@@ -30,7 +35,7 @@ export default function PressureDisplay({ measuredPressure, peep, pip }: any) {
             // contentInset={contentInset}
             style={styles.peepgauge}
             yMin={0}
-            yMax={100}
+            yMax={80}
             data={[measuredPressure]}
             svg={{ fill: Colors.BarColor }}
             animate={true}
@@ -57,6 +62,11 @@ export default function PressureDisplay({ measuredPressure, peep, pip }: any) {
             value={peep.value}
             title={peep.name}
             unit={peep.unit}></MetricDisplay>
+          <MetricDisplay
+            style={styles.peep}
+            title={plateauPressure.name}
+            value={plateauPressure.value}
+            unit={plateauPressure.unit}></MetricDisplay>
         </View>
       </View>
     </View>
@@ -72,7 +82,7 @@ export default function PressureDisplay({ measuredPressure, peep, pip }: any) {
 const styles = StyleSheet.create({
   peepgaugewithaxis: {
     flexDirection: 'row',
-    height: '67%',
+    height: '59%',
     paddingTop: 10,
     paddingBottom: 20,
     padding: 5,

--- a/src/components/PressureDisplay.tsx
+++ b/src/components/PressureDisplay.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet } from 'react-native';
 import { BarChart, Grid, YAxis } from 'react-native-svg-charts';
 import MetricDisplay from './MetricDisplay';
 import Colors from '../constants/Colors';
+import InitialReading from '../constants/InitialReading';
 
 export default function PressureDisplay({
   measuredPressure,
@@ -20,7 +21,7 @@ export default function PressureDisplay({
       <View style={{}}>
         <View style={styles.peepgaugewithaxis}>
           <YAxis
-            data={[0, 80]}
+            data={[0, InitialReading.pressureGraph.upperLimit]}
             contentInset={{ top: 4, bottom: 3 }}
             svg={{
               fill: Colors.TextColor,
@@ -34,8 +35,8 @@ export default function PressureDisplay({
           <BarChart
             // contentInset={contentInset}
             style={styles.peepgauge}
-            yMin={0}
-            yMax={80}
+            yMin={InitialReading.pressureGraph.lowerLimit}
+            yMax={InitialReading.pressureGraph.upperLimit}
             data={[measuredPressure]}
             svg={{ fill: Colors.BarColor }}
             animate={true}

--- a/src/constants/InitialReading.ts
+++ b/src/constants/InitialReading.ts
@@ -69,4 +69,8 @@ export default {
   graphVolume: new Array(Constants.GraphLength).fill(200),
   graphFlow: new Array(Constants.GraphLength).fill(150),
   alarms: [],
+  pressureGraph: {
+    upperLimit: 80,
+    lowerLimit: 0,
+  },
 };

--- a/src/constants/InitialReading.ts
+++ b/src/constants/InitialReading.ts
@@ -38,7 +38,7 @@ export default {
   vti: 100,
   vte: 400,
   minuteVentilation: {
-    name: 'Minute Ventilation',
+    name: 'Minute Vent.',
     unit: 'lpm',
     setValue: 10,
     value: 10,

--- a/src/enums/VentilationBreathingType.ts
+++ b/src/enums/VentilationBreathingType.ts
@@ -8,7 +8,7 @@ export class VentilationBreathingTypeUtils {
     breathingType: VentilationBreathingType,
   ): string {
     if (breathingType === VentilationBreathingType.Assisted) {
-      return 'AC-V';
+      return 'AC-';
     } else {
       return 'V';
     }

--- a/src/enums/VentilationBreathingType.ts
+++ b/src/enums/VentilationBreathingType.ts
@@ -8,7 +8,7 @@ export class VentilationBreathingTypeUtils {
     breathingType: VentilationBreathingType,
   ): string {
     if (breathingType === VentilationBreathingType.Assisted) {
-      return 'AC-';
+      return 'AC-V';
     } else {
       return 'V';
     }

--- a/src/logic/SerialParser.tsx
+++ b/src/logic/SerialParser.tsx
@@ -34,8 +34,8 @@ export const processSerialData = (
         unit: 'ml',
         setValue: setTidalVolume,
         value: measuredTidalVolume,
-        lowerLimit: Math.floor(setTidalVolume - (0.15 * setTidalVolume)),
-        upperLimit: Math.ceil(setTidalVolume + (0.15 * setTidalVolume)),
+        lowerLimit: Math.floor(setTidalVolume - 0.15 * setTidalVolume),
+        upperLimit: Math.ceil(setTidalVolume + 0.15 * setTidalVolume),
       };
 
       const measuredFlowRate = getWordFloat(
@@ -130,14 +130,23 @@ export const processSerialData = (
       };
 
       const setMinuteVentilation = (setTidalVolume / 1000) * setRespiratoryRate;
-      const measuredMinuteVentilation = getWordFloat(packet[34], packet[35], 40 / 65535, 0);
+      const measuredMinuteVentilation = getWordFloat(
+        packet[34],
+        packet[35],
+        40 / 65535,
+        0,
+      );
       const minuteVentilationParameter: SetParameter = {
-        name: 'Minute Ventilation',
+        name: 'Minute Vent.',
         unit: 'lpm',
         setValue: setMinuteVentilation,
         value: measuredMinuteVentilation,
-        lowerLimit: Math.floor(setMinuteVentilation - (0.10 * setMinuteVentilation)),
-        upperLimit: Math.ceil(setMinuteVentilation + (0.10 * setMinuteVentilation)),
+        lowerLimit: Math.floor(
+          setMinuteVentilation - 0.1 * setMinuteVentilation,
+        ),
+        upperLimit: Math.ceil(
+          setMinuteVentilation + 0.1 * setMinuteVentilation,
+        ),
       };
 
       updateReadingStateFunction({

--- a/src/logic/useReading.tsx
+++ b/src/logic/useReading.tsx
@@ -26,7 +26,7 @@ export const useReading = () => {
 // Provider hook that creates auth object and handles state
 function useProvideReading() {
   const [reading, setReading] = useState(InitialReading);
-  // const dummyGenerator = DummyDataGenerator(setReading, 20);
+  const dummyGenerator = DummyDataGenerator(setReading, 20);
   const serialDataHandler = SerialDataHandler({ baudRate: 115200 }, setReading);
 
   // Subscribe to user on mount
@@ -34,19 +34,19 @@ function useProvideReading() {
   // ... component that utilizes this hook to re-render with the ...
   // ... latest auth object.
   useEffect(() => {
-    serialDataHandler.startUsbListener();
+    // serialDataHandler.startUsbListener();
     console.log('starting generator');
-    // dummyGenerator.startGenerating();
+    dummyGenerator.startGenerating();
     // Cleanup subscription on unmount
-    return () => {
-      async function stopUSBListener() {
-        await serialDataHandler.stopUsbListener();
-      }
-    };
-    // return () => dummyGenerator.stopGenerating();
-    // }, []);
-  }, [serialDataHandler.state.connected]);
-
+    // return () => {
+    //   async function stopUSBListener() {
+    //     await serialDataHandler.stopUsbListener();
+    //   }
+    // };
+    return () => dummyGenerator.stopGenerating();
+  }, []);
+  // }, [serialDataHandler.state.connected]);
+  // },[]);
   // Return the user object and auth methods
   return {
     values: reading,

--- a/src/logic/useReading.tsx
+++ b/src/logic/useReading.tsx
@@ -26,7 +26,7 @@ export const useReading = () => {
 // Provider hook that creates auth object and handles state
 function useProvideReading() {
   const [reading, setReading] = useState(InitialReading);
-  const dummyGenerator = DummyDataGenerator(setReading, 20);
+  // const dummyGenerator = DummyDataGenerator(setReading, 20);
   const serialDataHandler = SerialDataHandler({ baudRate: 115200 }, setReading);
 
   // Subscribe to user on mount
@@ -34,18 +34,18 @@ function useProvideReading() {
   // ... component that utilizes this hook to re-render with the ...
   // ... latest auth object.
   useEffect(() => {
-    // serialDataHandler.startUsbListener();
+    serialDataHandler.startUsbListener();
     console.log('starting generator');
-    dummyGenerator.startGenerating();
+    // dummyGenerator.startGenerating();
     // Cleanup subscription on unmount
-    // return () => {
-    //   async function stopUSBListener() {
-    //     await serialDataHandler.stopUsbListener();
-    //   }
-    // };
-    return () => dummyGenerator.stopGenerating();
-  }, []);
-  // }, [serialDataHandler.state.connected]);
+    return () => {
+      async function stopUSBListener() {
+        await serialDataHandler.stopUsbListener();
+      }
+    };
+    // return () => dummyGenerator.stopGenerating();
+    // }, []);
+  }, [serialDataHandler.state.connected]);
   // },[]);
   // Return the user object and auth methods
   return {

--- a/src/navigation/BottomTabNavigator.tsx
+++ b/src/navigation/BottomTabNavigator.tsx
@@ -74,7 +74,7 @@ export default function BottomTabNavigator({
         name="Main"
         component={HomeScreen}
         options={{
-          title: 'main',
+          title: 'Main',
           tabBarIcon: ({ focused }) => (
             <TabBarIcon focused={focused} name="md-code-working" />
           ),
@@ -84,7 +84,7 @@ export default function BottomTabNavigator({
         name="Alarms"
         component={AlarmsScreen}
         options={{
-          title: 'Alarms',
+          title: 'Alarms and Monitoring',
           tabBarIcon: ({ focused }) => (
             <TabBarIcon focused={focused} name="md-alert" />
           ),

--- a/src/navigation/BottomTabNavigator.tsx
+++ b/src/navigation/BottomTabNavigator.tsx
@@ -13,8 +13,8 @@ const BottomTab = createBottomTabNavigator();
 const INITIAL_ROUTE_NAME = 'Main';
 
 function LogoTitle(props: any) {
-  const screenName = getHeaderTitle(props.route.name);
-  console.log('title' + screenName);
+  const screenName = getHeaderTitle(props.route);
+  console.log('title' + JSON.stringify(props.route));
   const screenwidth = Dimensions.get('window').width - 30;
   return (
     <View
@@ -50,6 +50,7 @@ export default function BottomTabNavigator({
   // currently active tab. Learn more in the documentation:
   // https://reactnavigation.org/docs/en/screen-options-resolution.html
   navigation.setOptions({
+    // console.log(JSON.stringify(route)),
     headerTitle: (props: any) => <LogoTitle route={route} {...props} />,
     // headerTitle: <LogoTitle></LogoTitle>,
     headerTintColor: Colors.TextColor,
@@ -73,6 +74,7 @@ export default function BottomTabNavigator({
         name="Main"
         component={HomeScreen}
         options={{
+          title: 'main',
           tabBarIcon: ({ focused }) => (
             <TabBarIcon focused={focused} name="md-code-working" />
           ),
@@ -82,7 +84,7 @@ export default function BottomTabNavigator({
         name="Alarms"
         component={AlarmsScreen}
         options={{
-          // title: 'Alarms',
+          title: 'Alarms',
           tabBarIcon: ({ focused }) => (
             <TabBarIcon focused={focused} name="md-alert" />
           ),

--- a/src/navigation/BottomTabNavigator.tsx
+++ b/src/navigation/BottomTabNavigator.tsx
@@ -114,7 +114,7 @@ function getHeaderTitle(route: any) {
     case 'Parameters':
       return 'Parameters';
     case 'Alarms':
-      return 'Alarms';
+      return 'Alarms and Monitoring';
     case 'Monitoring':
       return 'Monitoring';
     case 'LungMechanics':

--- a/src/navigation/BottomTabNavigator.tsx
+++ b/src/navigation/BottomTabNavigator.tsx
@@ -50,7 +50,6 @@ export default function BottomTabNavigator({
   // currently active tab. Learn more in the documentation:
   // https://reactnavigation.org/docs/en/screen-options-resolution.html
   navigation.setOptions({
-    // console.log(JSON.stringify(route)),
     headerTitle: (props: any) => <LogoTitle route={route} {...props} />,
     // headerTitle: <LogoTitle></LogoTitle>,
     headerTintColor: Colors.TextColor,
@@ -58,7 +57,6 @@ export default function BottomTabNavigator({
       backgroundColor: Colors.GeneralBackGround,
     },
   });
-  // console.log(JSON.stringify(route));
   return (
     <BottomTab.Navigator
       initialRouteName={INITIAL_ROUTE_NAME}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -17,7 +17,7 @@ export default function HomeScreen(props: any) {
   const readingValues = reading.values;
   const ventilatorConfig = initalVentilatorConfiguration;
 
-  console.log('homescreen ' + JSON.stringify(readingValues.minuteVentilation));
+  // console.log('homescreen ' + JSON.stringify(readingValues.minuteVentilation));
   return (
     <View style={styles.container}>
       <View style={styles.pressureDisplay}>
@@ -75,18 +75,16 @@ export default function HomeScreen(props: any) {
           title={readingValues.respiratoryRate.name}
           value={readingValues.respiratoryRate.setValue}
           unit={readingValues.respiratoryRate.unit}></MetricDisplay>
-        <MetricDisplay
-          style={styles.configuredvaluedisplay}
-          title={readingValues.tidalVolume.name}
-          value={readingValues.tidalVolume.setValue}
-          unit={readingValues.tidalVolume.unit}></MetricDisplay>
-
         <MetricDisplayString
           style={styles.configuredvaluedisplay}
           title={'I:E Ratio'}
           value={readingValues.ieRatio}
           unit={''}></MetricDisplayString>
-
+        <MetricDisplay
+          style={styles.configuredvaluedisplay}
+          title={readingValues.tidalVolume.name}
+          value={readingValues.tidalVolume.setValue}
+          unit={readingValues.tidalVolume.unit}></MetricDisplay>
         <MetricDisplay
           style={styles.configuredvaluedisplay}
           title={'VTi'}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -17,14 +17,15 @@ export default function HomeScreen(props: any) {
   const readingValues = reading.values;
   const ventilatorConfig = initalVentilatorConfiguration;
 
-  // console.log('homescreen');
+  console.log('homescreen ' + JSON.stringify(readingValues.minuteVentilation));
   return (
     <View style={styles.container}>
       <View style={styles.pressureDisplay}>
         <PressureDisplay
           measuredPressure={readingValues.measuredPressure}
           peep={readingValues.peep}
-          pip={readingValues.pip}></PressureDisplay>
+          pip={readingValues.pip}
+          plateauPressure={readingValues.plateauPressure}></PressureDisplay>
       </View>
       {/* <View style={styles.valuesandgraphs}> */}
       <View style={styles.graphs}>
@@ -42,12 +43,12 @@ export default function HomeScreen(props: any) {
         <View style={{ flex: 1, paddingTop: 0, paddingBottom: 0 }}>
           <Graphs
             data={readingValues.graphVolume}
-            yMin={0}
-            yMax={800}
+            yMin={-250}
+            yMax={600}
             numberOfTicks={4}
             fillColor={Colors.graphVolume}
             strokeColor={Colors.graphVolumeStrokeColor}
-          // style={{ maxheight: "50%" }}
+            // style={{ maxheight: "50%" }}
           ></Graphs>
         </View>
         <Text style={styles.graphTitle}>Flow Rate [lpm]</Text>
@@ -59,7 +60,7 @@ export default function HomeScreen(props: any) {
             numberOfTicks={4}
             fillColor={Colors.graphFlow}
             strokeColor={Colors.graphFlowStrokeColor}
-          // style={{ maxheight: "50%" }}
+            // style={{ maxheight: "50%" }}
           ></Graphs>
         </View>
       </View>
@@ -79,11 +80,6 @@ export default function HomeScreen(props: any) {
           title={readingValues.tidalVolume.name}
           value={readingValues.tidalVolume.setValue}
           unit={readingValues.tidalVolume.unit}></MetricDisplay>
-        <MetricDisplay
-          style={styles.configuredvaluedisplay}
-          title={readingValues.plateauPressure.name}
-          value={readingValues.plateauPressure.value}
-          unit={readingValues.plateauPressure.unit}></MetricDisplay>
 
         <MetricDisplayString
           style={styles.configuredvaluedisplay}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -17,7 +17,6 @@ export default function HomeScreen(props: any) {
   const readingValues = reading.values;
   const ventilatorConfig = initalVentilatorConfiguration;
 
-  // console.log('homescreen ' + JSON.stringify(readingValues.minuteVentilation));
   return (
     <View style={styles.container}>
       <View style={styles.pressureDisplay}>


### PR DESCRIPTION
This change updates the monitoring panel after some feedback from the team after use.

- Added space between tidal volume and flow rate graphs for consistency and readability
- Moved plateau pressure to left to have all pressure values display on one side
- Changed `Minute Ventilation` to `Minute vent` as it is overflowing on the tab screen, - Fixed the title of pages to show correct names when switched (Alarms and Main) 
- Changed the pressure bar to 80 instead of 100
- Changed the name of `Alarms` tab to `Alarms and Monitoring`

#16