### PR TITLE
Slight changes to main display

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -133,8 +133,8 @@ android {
         applicationId "com.openventpkventilatorapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 40
-        versionName "0.4.0"
+        versionCode 41
+        versionName "0.4.1"
     }
     splits {
         abi {

--- a/src/components/MetricDisplay.tsx
+++ b/src/components/MetricDisplay.tsx
@@ -24,7 +24,7 @@ export default function MetricDisplay(props: any) {
       <Text
         style={{
           alignSelf: 'center',
-          fontSize: 30,
+          fontSize: 25,
           color: Colors.ValueColor,
         }}>
         {parseFloat(props.value).toFixed(0)}{' '}
@@ -56,7 +56,7 @@ export function MetricDisplayString(props: any) {
       <Text
         style={{
           alignSelf: 'center',
-          fontSize: 30,
+          fontSize: 25,
           color: Colors.ValueColor,
         }}>
         {props.value}{' '}

--- a/src/components/PressureDisplay.tsx
+++ b/src/components/PressureDisplay.tsx
@@ -57,17 +57,21 @@ export default function PressureDisplay({
             style={styles.peep}
             value={pip.value}
             title={pip.name}
-            unit={pip.unit}></MetricDisplay>
-          <MetricDisplay
-            style={styles.peep}
-            value={peep.value}
-            title={peep.name}
-            unit={peep.unit}></MetricDisplay>
+            unit={pip.unit}
+          />
           <MetricDisplay
             style={styles.peep}
             title={plateauPressure.name}
             value={plateauPressure.value}
-            unit={plateauPressure.unit}></MetricDisplay>
+            unit={plateauPressure.unit}
+          />
+          <MetricDisplay
+            style={styles.peep}
+            value={peep.value}
+            title={peep.name}
+            unit={peep.unit}
+          />
+
         </View>
       </View>
     </View>

--- a/src/components/PressureDisplay.tsx
+++ b/src/components/PressureDisplay.tsx
@@ -71,7 +71,6 @@ export default function PressureDisplay({
             title={peep.name}
             unit={peep.unit}
           />
-
         </View>
       </View>
     </View>

--- a/src/constants/InitialReading.ts
+++ b/src/constants/InitialReading.ts
@@ -66,8 +66,8 @@ export default {
   },
   mode: 'VCV',
   graphPressure: new Array(Constants.GraphLength).fill(40),
-  graphVolume: new Array(Constants.GraphLength).fill(200),
-  graphFlow: new Array(Constants.GraphLength).fill(150),
+  graphVolume: new Array(Constants.GraphLength).fill(400),
+  graphFlow: new Array(Constants.GraphLength).fill(100),
   alarms: [],
   pressureGraph: {
     upperLimit: 80,


### PR DESCRIPTION
- Change order of metrics on `PressureDisplay`: `PIP`, `Plateau Pressure` and `PEEP` is the new order
- Some cleanup on the `PressureDisplay` component to use self-closing tags for `MetricDisplay`components
- Font size reduction to `25px` because there is some overflow on the used tablet for now
- Update Tidal Volume default to `400` to be in-line with other values to show two filled bars initially