### PR TITLE
Improve graph prominence

### DIFF
--- a/src/components/Graphs.tsx
+++ b/src/components/Graphs.tsx
@@ -9,8 +9,6 @@ export default function Graphs(props: any) {
     <View style={{ color: 'grey:' }}>
       <View>
         <View style={styles.graphwithaxis}>
-          {/* <View style={{ flex: 3 }}> */}
-
           {/* </View> */}
           <YAxis
             data={[props.yMin, props.yMax]}
@@ -29,12 +27,12 @@ export default function Graphs(props: any) {
             yMin={props.yMin}
             yMax={props.yMax}
             data={props.data}
-            svg={{ fill: props.fillColor, stroke: props.strokeColor }}
+            svg={{ fill: props.fillColor, stroke: props.strokeColor, strokeWidth: 3 }}
             // animate={true}
             // curve={shape.curveNatural}
             // showGrid={true}
             numberOfTicks={props.numberOfTicks}>
-            <Grid numberOfTicks={2} svg={{ stroke: Colors.gridLines }}></Grid>
+            <Grid numberOfTicks={2} svg={{ stroke: Colors.generalBackGround, fill: 'none' }}></Grid>
           </AreaChart>
         </View>
       </View>

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -54,7 +54,7 @@ export default function HomeScreen(props: any) {
         <View style={{ flex: 1, paddingTop: 0, paddingBottom: 0 }}>
           <Graphs
             data={readingValues.graphFlow}
-            yMin={-100}
+            yMin={-110}
             yMax={100}
             numberOfTicks={4}
             fillColor={Colors.graphFlow}


### PR DESCRIPTION
This change removes the tick lines from the graphs and increases the thickness of the stroke for each graph so that it is more prominently visible. The flow graph limits were also slightly altered so the `-100` is more viewable on the grid.

Close #70 