### PR TITLE
Draw all data points on graph with delayed interval

### DIFF
--- a/src/constants/DataConfig.ts
+++ b/src/constants/DataConfig.ts
@@ -1,5 +1,6 @@
 export default {
   totalPacketLength: 49,
-  updateInterval: 4,
-  graphLength: 250,
+  screenUpdateInterval: 4,
+  graphLength: 500,
+  dataFrequency: 50,
 };

--- a/src/logic/SerialParser.tsx
+++ b/src/logic/SerialParser.tsx
@@ -18,46 +18,46 @@ export const processSerialData = (
   totalPackets++;
   if (processIntegrityCheck(packet)) {
     interval++;
-    if (interval > DataConfig.updateInterval) {
+
+    const setTidalVolume = getWordFloat(packet[20], packet[21], 1, 0);
+    const measuredTidalVolume = getWordFloat(
+      packet[8],
+      packet[9],
+      4000 / 65535,
+      -2000,
+    );
+    addValueToGraph(measuredTidalVolume, volumeGraph, counterForGraphs);
+    const tidalVolumeParameter: SetParameter = {
+      name: 'Tidal Volume',
+      unit: 'ml',
+      setValue: setTidalVolume,
+      value: measuredTidalVolume,
+      lowerLimit: Math.floor(setTidalVolume - 0.15 * setTidalVolume),
+      upperLimit: Math.ceil(setTidalVolume + 0.15 * setTidalVolume),
+    };
+
+    const measuredFlowRate = getWordFloat(
+      packet[12],
+      packet[13],
+      400 / 65535,
+      -200,
+    );
+    addValueToGraph(measuredFlowRate, flowRateGraph, counterForGraphs);
+
+    const measuredPressure = getWordFloat(
+      packet[10],
+      packet[11],
+      90 / 65535,
+      -30,
+    );
+    addValueToGraph(measuredPressure, pressureGraph, counterForGraphs);
+
+    counterForGraphs++;
+    if (counterForGraphs >= DataConfig.graphLength) {
+      counterForGraphs = 0;
+    }
+    if (interval > DataConfig.screenUpdateInterval) {
       interval = 0;
-
-      const setTidalVolume = getWordFloat(packet[20], packet[21], 1, 0);
-      const measuredTidalVolume = getWordFloat(
-        packet[8],
-        packet[9],
-        4000 / 65535,
-        -2000,
-      );
-      addValueToGraph(measuredTidalVolume, volumeGraph, counterForGraphs);
-      const tidalVolumeParameter: SetParameter = {
-        name: 'Tidal Volume',
-        unit: 'ml',
-        setValue: setTidalVolume,
-        value: measuredTidalVolume,
-        lowerLimit: Math.floor(setTidalVolume - 0.15 * setTidalVolume),
-        upperLimit: Math.ceil(setTidalVolume + 0.15 * setTidalVolume),
-      };
-
-      const measuredFlowRate = getWordFloat(
-        packet[12],
-        packet[13],
-        400 / 65535,
-        -200,
-      );
-      addValueToGraph(measuredFlowRate, flowRateGraph, counterForGraphs);
-
-      const measuredPressure = getWordFloat(
-        packet[10],
-        packet[11],
-        90 / 65535,
-        -30,
-      );
-      addValueToGraph(measuredPressure, pressureGraph, counterForGraphs);
-
-      counterForGraphs++;
-      if (counterForGraphs >= DataConfig.graphLength) {
-        counterForGraphs = 0;
-      }
 
       const setPeep = packet[26] - 30;
       const measuredPeep = getWordFloat(

--- a/src/logic/useReading.tsx
+++ b/src/logic/useReading.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useContext, createContext } from 'react';
 import DummyDataGenerator from './DummyDataGenerator';
 import SerialDataHandler from './SerialDataHandler';
 import InitialReading from '../constants/InitialReading';
+import DataConfig from '../constants/DataConfig';
 
 const readingContext = createContext<any>(null);
 
@@ -26,7 +27,7 @@ export const useReading = () => {
 // Provider hook that creates auth object and handles state
 function useProvideReading() {
   const [reading, setReading] = useState(InitialReading);
-  // const dummyGenerator = DummyDataGenerator(setReading, 50);
+  // const dummyGenerator = DummyDataGenerator(setReading, DataConfig.dataFrequency);
   const serialDataHandler = SerialDataHandler({ baudRate: 115200 }, setReading);
 
   // Subscribe to user on mount


### PR DESCRIPTION
This change updates the graph logic so that we draw all the data points rather than one every 4 points. We still update our readings after every 4th reading, however because we faced performance issues when trying to update our graph 50 times in a second. The best result was achieved when we updated the graph after every 4 readings with all the included readings instead, giving up about 12.5 FPS

Close #63 