### PR TITLE
Add markers on graph to denote breath intake

### DIFF
--- a/src/components/Graphs.tsx
+++ b/src/components/Graphs.tsx
@@ -30,7 +30,7 @@ export default function Graphs(props: any) {
             svg={{ fill: props.fillColor, stroke: props.strokeColor, strokeWidth: 3 }}
             numberOfTicks={props.numberOfTicks}>
             <Grid numberOfTicks={2} svg={{ stroke: Colors.generalBackGround, fill: 'none' }}></Grid>
-            <Markers markerIndices={[10, 50, 100]} markerHeight={(props.yMax - props.yMin) * 0.1} />
+            <Markers markerIndices={props.markers} markerHeight={(props.yMax - props.yMin) * 0.1} />
           </AreaChart>
         </View>
       </View>

--- a/src/components/Graphs.tsx
+++ b/src/components/Graphs.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { Text, View, StyleSheet, ViewPropTypes } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { AreaChart, Grid, YAxis } from 'react-native-svg-charts';
 import Colors from '../constants/Colors';
-import { RotationGestureHandler } from 'react-native-gesture-handler';
+import Markers from './Marker';
 
 export default function Graphs(props: any) {
+
   return (
     <View style={{ color: Colors.graphBarColor }}>
       <View>
@@ -22,17 +23,14 @@ export default function Graphs(props: any) {
             style={{ flex: 2 }}
           />
           <AreaChart
-            // contentInset={contentInset}
             style={styles.graph}
             yMin={props.yMin}
             yMax={props.yMax}
             data={props.data}
             svg={{ fill: props.fillColor, stroke: props.strokeColor, strokeWidth: 3 }}
-            // animate={true}
-            // curve={shape.curveNatural}
-            // showGrid={true}
             numberOfTicks={props.numberOfTicks}>
             <Grid numberOfTicks={2} svg={{ stroke: Colors.generalBackGround, fill: 'none' }}></Grid>
+            <Markers markerIndices={[10, 50, 100]} markerHeight={(props.yMax - props.yMin) * 0.1} />
           </AreaChart>
         </View>
       </View>

--- a/src/components/Marker.tsx
+++ b/src/components/Marker.tsx
@@ -2,9 +2,11 @@ import * as React from 'react';
 import { Polygon } from 'react-native-svg';
 
 export default function Markers({ x, y, markerIndices, markerHeight }) {
+  if (markerIndices === undefined) {
+    markerIndices = [];
+  }
 
-  return (
-    markerIndices.map((markerIndex: number) => (
+  return markerIndices.map((markerIndex: number) => (
     <Polygon
       key={markerIndex}
       points={[
@@ -14,8 +16,6 @@ export default function Markers({ x, y, markerIndices, markerHeight }) {
       ]}
       stroke="white"
       fill="white"
-      />
-    ))
-  );
+    />
+  ));
 }
-

--- a/src/components/Marker.tsx
+++ b/src/components/Marker.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { Polygon } from 'react-native-svg';
+
+export default function Markers({ x, y, markerIndices, markerHeight }) {
+
+  return (
+    markerIndices.map((markerIndex: number) => (
+    <Polygon
+      key={markerIndex}
+      points={[
+        [x(markerIndex), y(-5)],
+        [x(markerIndex - 5), y(-5 - markerHeight)],
+        [x(markerIndex + 5), y(-5 - markerHeight)],
+      ]}
+      stroke="white"
+      fill="white"
+      />
+    ))
+  );
+}
+

--- a/src/constants/InitialReading.ts
+++ b/src/constants/InitialReading.ts
@@ -1,4 +1,5 @@
 import DataConfig from './DataConfig';
+import { BreathingPhase } from '../enums/BreathingPhase';
 
 export default {
   peep: {
@@ -74,4 +75,6 @@ export default {
     upperLimit: 80,
     lowerLimit: 0,
   },
+  breathingPhase: BreathingPhase.Hold,
+  breathMarkers: [],
 };

--- a/src/enums/BreathingPhase.ts
+++ b/src/enums/BreathingPhase.ts
@@ -1,0 +1,6 @@
+export enum BreathingPhase {
+  Wait = 0,
+  Inspiratory = 1,
+  Hold = 2,
+  Expiratory = 3,
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -47,7 +47,6 @@ export default function HomeScreen(props: any) {
             numberOfTicks={4}
             fillColor={Colors.graphVolume}
             strokeColor={Colors.graphVolumeStrokeColor}
-          // style={{ maxheight: "50%" }}
           ></Graphs>
         </View>
         <Text style={styles.graphTitle}>Flow Rate [lpm]</Text>
@@ -60,7 +59,6 @@ export default function HomeScreen(props: any) {
             fillColor={Colors.graphFlow}
             strokeColor={Colors.graphFlowStrokeColor}
             markers={readingValues.breathMarkers}
-          // style={{ maxheight: "50%" }}
           ></Graphs>
         </View>
       </View>

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -47,7 +47,7 @@ export default function HomeScreen(props: any) {
             numberOfTicks={4}
             fillColor={Colors.graphVolume}
             strokeColor={Colors.graphVolumeStrokeColor}
-            // style={{ maxheight: "50%" }}
+          // style={{ maxheight: "50%" }}
           ></Graphs>
         </View>
         <Text style={styles.graphTitle}>Flow Rate [lpm]</Text>
@@ -59,7 +59,8 @@ export default function HomeScreen(props: any) {
             numberOfTicks={4}
             fillColor={Colors.graphFlow}
             strokeColor={Colors.graphFlowStrokeColor}
-            // style={{ maxheight: "50%" }}
+            markers={readingValues.breathMarkers}
+          // style={{ maxheight: "50%" }}
           ></Graphs>
         </View>
       </View>


### PR DESCRIPTION
This change monitors the breathing phase whenever data is parsed. If it detects the start of a new breath, it marks the data point for the graph and passes it along. In the `Graph` component, we have added a `Marker` component, which will create a triangle at the said location, below the `0` value in the graph. Once our graph is overwritten with new values, the markers from those position will be removed.

Close #61 