### PR TITLE
Add local log of readings

### DIFF
--- a/src/constants/Alarms.ts
+++ b/src/constants/Alarms.ts
@@ -13,7 +13,7 @@ export default [
   'Oxygen Failure',
   'Low Tidal Volume',
   'High Tidal Volume',
-  'System Reset - Please Recheck FiO2, PEEP and Minute Ventilation Settings',
+  'System Reset - Please Recheck FiO2/PEEP/Minute Ventilation Settings',
   'Low Minute Ventilation',
   'High Minute Ventilation',
   'Patient Vent Circuit Disconnected',

--- a/src/constants/InitialReading.ts
+++ b/src/constants/InitialReading.ts
@@ -46,8 +46,6 @@ export default {
     lowerLimit: 9,
     upperLimit: 11,
   },
-  inspiratoryTime: 3,
-  expiratoryTime: 5,
   fiO2: {
     name: 'FiO2',
     upperLimit: 100,

--- a/src/logic/DataLogger.ts
+++ b/src/logic/DataLogger.ts
@@ -4,10 +4,11 @@ import SetParameter from '../interfaces/SetParameter';
 import DataConfig from '../constants/DataConfig';
 import { BreathingPhase } from '../enums/BreathingPhase';
 
+// TODO: Add serial data packets also
 export default function dataLogger() {
   const nowTimeStamp: string = new Date().toISOString().replace(/\.|:/g, '-');
-  const logDirectory: string = `${RNFS.ExternalDirectoryPath}/readings`;
-  const logFile: string = `${nowTimeStamp}-readings.csv`;
+  const logDirectory: string = `${RNFS.ExternalDirectoryPath}/sessions`;
+  const logFile: string = `${nowTimeStamp}.csv`;
   const folderCreationPromise = RNFS.mkdir(logDirectory);
   let readingsCsv: string[] = [getDataHeaders()];
   const logFrequency: number =

--- a/src/logic/DataLogger.ts
+++ b/src/logic/DataLogger.ts
@@ -2,33 +2,69 @@ import * as RNFS from 'react-native-fs';
 import Alarms from '../constants/Alarms';
 import SetParameter from '../interfaces/SetParameter';
 import DataConfig from '../constants/DataConfig';
+import { BreathingPhase } from '../enums/BreathingPhase';
 
 export default function dataLogger() {
   const nowTimeStamp: string = new Date().toISOString().replace(/\.|:/g, '-');
   const logDirectory: string = `${RNFS.ExternalDirectoryPath}/readings`;
   const logFile: string = `${nowTimeStamp}-readings.csv`;
   const folderCreationPromise = RNFS.mkdir(logDirectory);
-  let readingsCsv: string[] = [];
+  let readingsCsv: string[] = [getDataHeaders()];
   const logFrequency: number =
     (DataConfig.graphLength / DataConfig.dataFrequency) * 1000; // log every time the graph clears
-  let intervalFunction: number = setInterval(() => {
+
+  setInterval(() => {
     if (readingsCsv.length > 0) {
-      writeToLogFile();
+      writeToLogFile(readingsCsv.length);
     }
   }, logFrequency);
+
+  function getDataHeaders() {
+    return [
+      'Timestamp',
+      'Measured Pressure',
+      getSetParameterHeader('Peep'),
+      getSetParameterHeader('PIP'),
+      getSetParameterHeader('Plateau Pressure'),
+      getSetParameterHeader('Patient Rate'),
+      getSetParameterHeader('Tidal Volume'),
+      'I/E Ratio',
+      'VTi',
+      'VTe',
+      getSetParameterHeader('Minute Ventilation'),
+      getSetParameterHeader('Fi O2'),
+      'Flow Rate',
+      'Ventilation Mode',
+      'Breathing Phase',
+      getAlarmHeaders(),
+    ].join(',');
+  }
+
+  function getSetParameterHeader(parameterName: string) {
+    return [
+      `${parameterName} Set Value`,
+      `${parameterName} Measured Value`,
+      `${parameterName} Lower Limit`,
+      `${parameterName} Upper Limit`,
+    ].join(',');
+  }
+
+  function getAlarmHeaders() {
+    return Alarms.join(',');
+  }
 
   function onDataReading(reading: any) {
     const readingInCsv = getCsvFormat(reading);
     readingsCsv.push(readingInCsv);
   }
 
-  function writeToLogFile() {
+  function writeToLogFile(numberOfReadingsAdded: number) {
     const readingsToAdd: string = readingsCsv.join('\n');
     folderCreationPromise.then(() => {
-      RNFS.write(`${logDirectory}/${logFile}`, readingsToAdd)
+      RNFS.write(`${logDirectory}/${logFile}`, readingsToAdd + '\n')
         .then(() => {
           console.log(`written to ${logFile}`);
-          readingsCsv = [];
+          readingsCsv = readingsCsv.slice(numberOfReadingsAdded);
         })
         .catch((err) => {
           console.log(err.message);
@@ -47,8 +83,6 @@ export default function dataLogger() {
       vti,
       vte,
       minuteVentilation,
-      inspiratoryTime,
-      expiratoryTime,
       fiO2,
       flowRate,
       pip,
@@ -58,35 +92,39 @@ export default function dataLogger() {
     } = reading;
     let readingsString: string = [
       new Date().toISOString(),
-      peep,
       measuredPressure,
-      plateauPressure,
-      respiratoryRate,
-      tidalVolume,
+      getSetParameterCsvFormat(peep),
+      getSetParameterCsvFormat(pip),
+      getSetParameterCsvFormat(plateauPressure),
+      getSetParameterCsvFormat(respiratoryRate),
+      getSetParameterCsvFormat(tidalVolume),
       ieRatio,
       vti,
       vte,
-      minuteVentilation,
-      inspiratoryTime,
-      expiratoryTime,
-      fiO2,
+      getSetParameterCsvFormat(minuteVentilation),
+      getSetParameterCsvFormat(fiO2),
       flowRate,
-      pip,
       mode,
-      breathingPhase,
+      BreathingPhase[breathingPhase],
       getAlarmsInCsvFormat(alarms),
     ].join(',');
     return readingsString;
   }
 
+  function getSetParameterCsvFormat(paramter: SetParameter) {
+    return [
+      paramter.setValueText || paramter.setValue,
+      paramter.value,
+      paramter.lowerLimit,
+      paramter.upperLimit,
+    ].join(',');
+  }
+
   function getAlarmsInCsvFormat(alarms: string[]): string {
-    let alarmPresenceArray: boolean[] = [];
-    var allAlarms = Alarms;
-    for (const alarm in allAlarms) {
-      if (alarms.includes(alarm)) {
-        alarmPresenceArray.push(true);
-      } else {
-        alarmPresenceArray.push(false);
+    let alarmPresenceArray: boolean[] = new Array(Alarms.length).fill(false);
+    for (let i = 0; i < Alarms.length; i++) {
+      if (alarms.includes(Alarms[i])) {
+        alarmPresenceArray[i] = true;
       }
     }
     return alarmPresenceArray.join(',');

--- a/src/logic/DataLogger.ts
+++ b/src/logic/DataLogger.ts
@@ -1,0 +1,77 @@
+import * as RNFS from 'react-native-fs';
+import Alarms from '../constants/Alarms';
+
+export default function dataLogger() {
+  const nowTimeStamp: string = new Date().toISOString().replace(':','-');
+  const logFile: string = `${RNFS.DocumentDirectoryPath}/${nowTimeStamp}_readings.csv`;
+
+  function onDataReading(reading: any) {
+    var readingInCsv = getCsvFormat(reading);
+    RNFS.write(logFile, readingInCsv)
+      .then(() => {
+        console.log(`written to ${logFile}`);
+      })
+      .catch((err) => {
+        console.log(err.message);
+      });
+  }
+
+  function getCsvFormat(reading: any): string {
+    const {
+      peep,
+      measuredPressure,
+      plateauPressure,
+      respiratoryRate,
+      tidalVolume,
+      ieRatio,
+      vti,
+      vte,
+      minuteVentilation,
+      inspiratoryTime,
+      expiratoryTime,
+      fiO2,
+      flowRate,
+      pip,
+      mode,
+      alarms,
+      breathingPhase,
+    } = reading;
+    let readingsString: string = [
+      peep,
+      measuredPressure,
+      plateauPressure,
+      respiratoryRate,
+      tidalVolume,
+      ieRatio,
+      vti,
+      vte,
+      minuteVentilation,
+      inspiratoryTime,
+      expiratoryTime,
+      fiO2,
+      flowRate,
+      pip,
+      mode,
+      breathingPhase,
+      getAlarmsInCsvFormat(alarms),
+    ].join(',');
+    return readingsString;
+  }
+
+  function getAlarmsInCsvFormat(alarms: string[]): string {
+    let alarmPresenceArray: boolean[] = [];
+    var allAlarms = Alarms;
+    for (const alarm in allAlarms) {
+      if (alarms.includes(alarm)) {
+        alarmPresenceArray.push(true);
+      } else {
+        alarmPresenceArray.push(false);
+      }
+    }
+    return alarmPresenceArray.join(',');
+  }
+
+  return {
+    onDataReading,
+  };
+}

--- a/src/logic/DataLogger.ts
+++ b/src/logic/DataLogger.ts
@@ -1,19 +1,25 @@
 import * as RNFS from 'react-native-fs';
 import Alarms from '../constants/Alarms';
+import SetParameter from '../interfaces/SetParameter';
 
 export default function dataLogger() {
-  const nowTimeStamp: string = new Date().toISOString().replace(':','-');
-  const logFile: string = `${RNFS.DocumentDirectoryPath}/${nowTimeStamp}_readings.csv`;
+  const nowTimeStamp: string = new Date().toISOString().replace(/\.|:/g, '-');
+  const logDirectory: string = `${RNFS.ExternalDirectoryPath}/readings`;
+  const logFile: string = `${nowTimeStamp}-readings.csv`;
+
+  const folderCreationPromise = RNFS.mkdir(logDirectory);
 
   function onDataReading(reading: any) {
     var readingInCsv = getCsvFormat(reading);
-    RNFS.write(logFile, readingInCsv)
-      .then(() => {
-        console.log(`written to ${logFile}`);
-      })
-      .catch((err) => {
-        console.log(err.message);
-      });
+    folderCreationPromise.then(() => {
+      RNFS.write(`${logDirectory}/${logFile}`, readingInCsv)
+        .then(() => {
+          console.log(`written to ${logFile}`);
+        })
+        .catch((err) => {
+          console.log(err.message);
+        });
+    });
   }
 
   function getCsvFormat(reading: any): string {
@@ -56,6 +62,10 @@ export default function dataLogger() {
       getAlarmsInCsvFormat(alarms),
     ].join(',');
     return readingsString;
+  }
+
+  function getSetParameterCsvFormat(parameter: SetParameter): string {
+
   }
 
   function getAlarmsInCsvFormat(alarms: string[]): string {

--- a/src/logic/SerialParser.tsx
+++ b/src/logic/SerialParser.tsx
@@ -3,6 +3,7 @@ import Alarms from '../constants/Alarms';
 import VentilationModes from '../constants/VentilationModes';
 import SetParameter from '../interfaces/SetParameter';
 import { BreathingPhase } from '../enums/BreathingPhase';
+import DataLogger from './DataLogger';
 
 let pressureGraph = new Array(DataConfig.graphLength).fill(null);
 let volumeGraph = new Array(DataConfig.graphLength).fill(null);
@@ -13,6 +14,7 @@ let interval = 0;
 let counterForGraphs = 0;
 let breathMarkers: number[] = [];
 let previousBreath: BreathingPhase = BreathingPhase.Wait;
+const dataLogger = DataLogger();
 
 export const processSerialData = (
   packet: any,
@@ -72,126 +74,119 @@ export const processSerialData = (
     if (counterForGraphs >= DataConfig.graphLength) {
       counterForGraphs = 0;
     }
+
+    const setPeep = packet[26] - 30;
+    const measuredPeep = getWordFloat(packet[14], packet[15], 40 / 65535, -10);
+    const peepParameter: SetParameter = {
+      name: 'PEEP',
+      unit: 'cmH2O',
+      setValue: setPeep,
+      value: measuredPeep,
+      lowerLimit: 4,
+      upperLimit: 21,
+    };
+
+    const setInspiratoryPressure = packet[22] - 30;
+
+    const measuredPip = packet[40] - 30;
+    const pipParameter: SetParameter = {
+      name: 'PIP',
+      unit: 'cmH2O',
+      setValue: setInspiratoryPressure,
+      value: measuredPip,
+      lowerLimit: setInspiratoryPressure - 5,
+      upperLimit: setInspiratoryPressure + 5,
+    };
+
+    const measuredPlateauPressure = getWordFloat(
+      packet[16],
+      packet[17],
+      90 / 65535,
+      -30,
+    );
+
+    const plateauPressureParameter: SetParameter = {
+      name: 'Plateau Pressure',
+      unit: 'cmH2O',
+      setValue: setInspiratoryPressure,
+      value: measuredPlateauPressure,
+      lowerLimit: setInspiratoryPressure - 2,
+      upperLimit: setInspiratoryPressure + 2,
+    };
+
+    const ventilationMode = getVentilationMode(packet[29]);
+
+    let currentAlarms = getAlarmValues(packet);
+
+    const setFiO2lowerBound = packet[25];
+    const setFiO2upperBound = packet[44];
+    const measuredFiO2 = getWordFloat(packet[18], packet[19], 100 / 65535, 0);
+    const fiO2Parameter: SetParameter = {
+      name: 'FiO2',
+      unit: '%',
+      setValue: setFiO2lowerBound,
+      setValueText: `${setFiO2lowerBound}-${setFiO2upperBound}`,
+      value: measuredFiO2,
+      lowerLimit: setFiO2lowerBound - 2,
+      upperLimit: setFiO2upperBound + 2,
+    };
+
+    const setRespiratoryRate = packet[23];
+    const measuredRespiratoryRate = packet[39];
+    const respiratoryRateParameter: SetParameter = {
+      name: 'Patient Rate',
+      unit: 'BPM',
+      setValue: setRespiratoryRate,
+      value: measuredRespiratoryRate,
+      lowerLimit: setRespiratoryRate - 1,
+      upperLimit: setRespiratoryRate + 1,
+    };
+
+    const setMinuteVentilation = (setTidalVolume / 1000) * setRespiratoryRate;
+    const measuredMinuteVentilation = getWordFloat(
+      packet[34],
+      packet[35],
+      40 / 65535,
+      0,
+    );
+    const minuteVentilationParameter: SetParameter = {
+      name: 'Minute Vent.',
+      unit: 'lpm',
+      setValue: setMinuteVentilation,
+      value: measuredMinuteVentilation,
+      lowerLimit: Math.floor(setMinuteVentilation - 0.1 * setMinuteVentilation),
+      upperLimit: Math.ceil(setMinuteVentilation + 0.1 * setMinuteVentilation),
+    };
+    const reading: any = {
+      peep: peepParameter,
+      measuredPressure: measuredPressure,
+      plateauPressure: plateauPressureParameter,
+      respiratoryRate: respiratoryRateParameter,
+      tidalVolume: tidalVolumeParameter,
+      ieRatio: (packet[24] & 0x0f) + ':' + (packet[24] & 0xf0) / 16,
+      vti: getWordFloat(packet[30], packet[31], 4000 / 65535, -2000),
+      vte: getWordFloat(packet[32], packet[33], 4000 / 65535, -2000),
+      minuteVentilation: minuteVentilationParameter,
+      inspiratoryTime: 1,
+      expiratoryTime: 5,
+      fiO2: fiO2Parameter,
+      flowRate: measuredFlowRate,
+      pip: pipParameter,
+      mode: ventilationMode,
+      graphPressure: pressureGraph,
+      graphVolume: volumeGraph,
+      graphFlow: flowRateGraph,
+      packetIntegrityRatio: `${failedPackets} / ${totalPackets}`,
+      alarms: currentAlarms,
+      breathingPhase: breathingPhase,
+      breathMarkers: breathMarkers,
+    };
+    dataLogger.onDataReading(reading);
+
+    totalPackets++;
     if (interval > DataConfig.screenUpdateInterval) {
       interval = 0;
-
-      const setPeep = packet[26] - 30;
-      const measuredPeep = getWordFloat(
-        packet[14],
-        packet[15],
-        40 / 65535,
-        -10,
-      );
-      const peepParameter: SetParameter = {
-        name: 'PEEP',
-        unit: 'cmH2O',
-        setValue: setPeep,
-        value: measuredPeep,
-        lowerLimit: 4,
-        upperLimit: 21,
-      };
-
-      const setInspiratoryPressure = packet[22] - 30;
-
-      const measuredPip = packet[40] - 30;
-      const pipParameter: SetParameter = {
-        name: 'PIP',
-        unit: 'cmH2O',
-        setValue: setInspiratoryPressure,
-        value: measuredPip,
-        lowerLimit: setInspiratoryPressure - 5,
-        upperLimit: setInspiratoryPressure + 5,
-      };
-
-      const measuredPlateauPressure = getWordFloat(
-        packet[16],
-        packet[17],
-        90 / 65535,
-        -30,
-      );
-
-      const plateauPressureParameter: SetParameter = {
-        name: 'Plateau Pressure',
-        unit: 'cmH2O',
-        setValue: setInspiratoryPressure,
-        value: measuredPlateauPressure,
-        lowerLimit: setInspiratoryPressure - 2,
-        upperLimit: setInspiratoryPressure + 2,
-      };
-
-      const ventilationMode = getVentilationMode(packet[29]);
-
-      let currentAlarms = getAlarmValues(packet);
-
-      const setFiO2lowerBound = packet[25];
-      const setFiO2upperBound = packet[44];
-      const measuredFiO2 = getWordFloat(packet[18], packet[19], 100 / 65535, 0);
-      const fiO2Parameter: SetParameter = {
-        name: 'FiO2',
-        unit: '%',
-        setValue: setFiO2lowerBound,
-        setValueText: `${setFiO2lowerBound}-${setFiO2upperBound}`,
-        value: measuredFiO2,
-        lowerLimit: setFiO2lowerBound - 2,
-        upperLimit: setFiO2upperBound + 2,
-      };
-
-      const setRespiratoryRate = packet[23];
-      const measuredRespiratoryRate = packet[39];
-      const respiratoryRateParameter: SetParameter = {
-        name: 'Patient Rate',
-        unit: 'BPM',
-        setValue: setRespiratoryRate,
-        value: measuredRespiratoryRate,
-        lowerLimit: setRespiratoryRate - 1,
-        upperLimit: setRespiratoryRate + 1,
-      };
-
-      const setMinuteVentilation = (setTidalVolume / 1000) * setRespiratoryRate;
-      const measuredMinuteVentilation = getWordFloat(
-        packet[34],
-        packet[35],
-        40 / 65535,
-        0,
-      );
-      const minuteVentilationParameter: SetParameter = {
-        name: 'Minute Vent.',
-        unit: 'lpm',
-        setValue: setMinuteVentilation,
-        value: measuredMinuteVentilation,
-        lowerLimit: Math.floor(
-          setMinuteVentilation - 0.1 * setMinuteVentilation,
-        ),
-        upperLimit: Math.ceil(
-          setMinuteVentilation + 0.1 * setMinuteVentilation,
-        ),
-      };
-
-      updateReadingStateFunction({
-        peep: peepParameter,
-        measuredPressure: measuredPressure,
-        plateauPressure: plateauPressureParameter,
-        respiratoryRate: respiratoryRateParameter,
-        tidalVolume: tidalVolumeParameter,
-        ieRatio: (packet[24] & 0x0f) + ':' + (packet[24] & 0xf0) / 16,
-        vti: getWordFloat(packet[30], packet[31], 4000 / 65535, -2000),
-        vte: getWordFloat(packet[32], packet[33], 4000 / 65535, -2000),
-        minuteVentilation: minuteVentilationParameter,
-        inspiratoryTime: 1,
-        expiratoryTime: 5,
-        fiO2: fiO2Parameter,
-        flowRate: measuredFlowRate,
-        pip: pipParameter,
-        mode: ventilationMode,
-        graphPressure: pressureGraph,
-        graphVolume: volumeGraph,
-        graphFlow: flowRateGraph,
-        packetIntegrityRatio: `${failedPackets} / ${totalPackets}`,
-        alarms: currentAlarms,
-        breathingPhase: breathingPhase,
-        breathMarkers: breathMarkers,
-      });
-      totalPackets++;
+      updateReadingStateFunction(reading);
     }
   } else {
     failedPackets++;

--- a/src/logic/SerialParser.tsx
+++ b/src/logic/SerialParser.tsx
@@ -158,8 +158,9 @@ export const processSerialData = (
       upperLimit: Math.ceil(setMinuteVentilation + 0.1 * setMinuteVentilation),
     };
     const reading: any = {
-      peep: peepParameter,
       measuredPressure: measuredPressure,
+      peep: peepParameter,
+      pip: pipParameter,
       plateauPressure: plateauPressureParameter,
       respiratoryRate: respiratoryRateParameter,
       tidalVolume: tidalVolumeParameter,
@@ -167,11 +168,8 @@ export const processSerialData = (
       vti: getWordFloat(packet[30], packet[31], 4000 / 65535, -2000),
       vte: getWordFloat(packet[32], packet[33], 4000 / 65535, -2000),
       minuteVentilation: minuteVentilationParameter,
-      inspiratoryTime: 1,
-      expiratoryTime: 5,
       fiO2: fiO2Parameter,
       flowRate: measuredFlowRate,
-      pip: pipParameter,
       mode: ventilationMode,
       graphPressure: pressureGraph,
       graphVolume: volumeGraph,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     /* Basic Options */
     "target": "esnext",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": ["es6"],                           /* Specify library files to be included in the compilation. */
+    "lib": ["es6", "es7"],                           /* Specify library files to be included in the compilation. */
     "allowJs": true,                          /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     "jsx": "react-native",                    /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
This change adds functionality to allow logging of all the readings to local space. This has been done by adding a `DataLogger` module which is used inside `SerialParser`. `SerialParser` calls `DataLogger`'s `OnDataReceived` function every time it has a valid reading. The `DataLogger` function then creates a csv version of the reading and adds it to its internal array. Every time our graph clears, our `DataLogger` writes all the readings it has collected until now into a csv file in the data folder. This file is timestamped so it remains unique. Each separate file is then considered a separate session.

Close #84 