### PR TITLE
Display measured values for FiO2 and Patient Rate

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -66,12 +66,12 @@ export default function HomeScreen(props: any) {
         <MetricDisplayString
           style={styles.configuredvaluedisplay}
           title={readingValues.fiO2.name}
-          value={readingValues.fiO2.setValueText}
+          value={readingValues.fiO2.value}
           unit={readingValues.fiO2.unit}></MetricDisplayString>
         <MetricDisplay
           style={styles.configuredvaluedisplay}
           title={readingValues.respiratoryRate.name}
-          value={readingValues.respiratoryRate.setValue}
+          value={readingValues.respiratoryRate.value}
           unit={readingValues.respiratoryRate.unit}></MetricDisplay>
         <MetricDisplayString
           style={styles.configuredvaluedisplay}


### PR DESCRIPTION
The measured values of these two parameters should be displayed on the monitor page instead of the set values. FiO2 set value can be checked on the alarms page.

Close #82 