### PR TITLE
Show blank tidal volume set point on pressure control modes

### DIFF
--- a/src/components/MetricDisplay.tsx
+++ b/src/components/MetricDisplay.tsx
@@ -27,7 +27,7 @@ export default function MetricDisplay(props: any) {
           fontSize: 25,
           color: Colors.valueColor,
         }}>
-        {parseFloat(props.value).toFixed(0)}{' '}
+        {props.value != null ? parseFloat(props.value).toFixed(0) : '-'}{' '}
         <Text style={{ alignSelf: 'center', fontSize: 15 }}>{props.unit}</Text>
       </Text>
     </View>

--- a/src/components/TidalVolumeMetricDisplay.tsx
+++ b/src/components/TidalVolumeMetricDisplay.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import MetricDisplay from './MetricDisplay';
+
+export default function TidalVolumeMetricDisplay(props: any) {
+  const { ventilationMode, parameter } = props;
+  if (ventilationMode === 'PCV' || ventilationMode === 'AC-PCV') {
+    parameter.setValue = null;
+  }
+
+  return (
+    <MetricDisplay
+      title={parameter.name}
+      value={parameter.setValue}
+      unit={parameter.unit}
+    />
+  );
+}

--- a/src/constants/InitialReading.ts
+++ b/src/constants/InitialReading.ts
@@ -64,7 +64,7 @@ export default {
     lowerLimit: 100,
     upperLimit: 0,
   },
-  mode: 'VCV',
+  mode: 'PCV',
   graphPressure: new Array(DataConfig.graphLength).fill(null),
   graphVolume: new Array(DataConfig.graphLength).fill(null),
   graphFlow: new Array(DataConfig.graphLength).fill(null),

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -9,9 +9,9 @@ import { useReading } from '../logic/useReading';
 import { MetricDisplayString } from '../components/MetricDisplay';
 import initalVentilatorConfiguration from '../constants/InitialVentilatorConfiguration';
 import SetParameter from 'src/interfaces/SetParameter';
-
-// import { Colors } from 'react-native/Libraries/NewAppScreen';
 import Colors from '../constants/Colors';
+import TidalVolumeMetricDisplay from '../components/TidalVolumeMetricDisplay';
+
 export default function HomeScreen(props: any) {
   const reading = useReading();
   const readingValues = reading.values;
@@ -78,11 +78,11 @@ export default function HomeScreen(props: any) {
           title={'I:E Ratio'}
           value={readingValues.ieRatio}
           unit={''}></MetricDisplayString>
-        <MetricDisplay
+        <TidalVolumeMetricDisplay
           style={styles.configuredvaluedisplay}
-          title={readingValues.tidalVolume.name}
-          value={readingValues.tidalVolume.setValue}
-          unit={readingValues.tidalVolume.unit}></MetricDisplay>
+          parameter={readingValues.tidalVolume}
+          ventilationMode={readingValues.mode}
+        />
         <MetricDisplay
           style={styles.configuredvaluedisplay}
           title={'VTi'}


### PR DESCRIPTION
When our ventilation mode is pressure controlled i.e. `PCV` or `AC-PCV`, we need to show a blank value for our tidal volume set point in our monitoring display. To best handle this, a new component, `TidalVolumeMetricDisplay` was created, to encapsulate this ventilation check logic, taking in the ventilation mode and tidal volume parameter,setting the paramter set value to null in case of the relevant ventilation modes. In our `MetricDisplay` component, we handle null values by showng a `-`.

Close #81 