### PR TITLE
Only snooze sound on banner interaction

### DIFF
--- a/src/logic/AlarmsManager.ts
+++ b/src/logic/AlarmsManager.ts
@@ -40,7 +40,7 @@ function AlarmsManager() {
       type: 'danger',
       icon: 'danger',
       autoHide: false,
-      hideOnPress: true,
+      hideOnPress: false,
       onPress: () => {
         alarmSound.stop();
       },

--- a/src/logic/AlarmsManager.ts
+++ b/src/logic/AlarmsManager.ts
@@ -38,7 +38,7 @@ function AlarmsManager() {
       message: 'Alarm(s) active',
       description: alarmsText,
       type: 'danger',
-      icon: 'danger',
+      icon: 'warning',
       autoHide: false,
       hideOnPress: false,
       onPress: () => {


### PR DESCRIPTION
The alarms banner should never disappear when touched - only the sound should be snoozed. This has been implemented and the icon changed to show alarm rather than a cross.

Close #78 