### PR TITLE
Disable snoozing of Peak Pressure Alarm

### DIFF
--- a/src/logic/AlarmsManager.ts
+++ b/src/logic/AlarmsManager.ts
@@ -42,7 +42,10 @@ function AlarmsManager() {
       autoHide: false,
       hideOnPress: false,
       onPress: () => {
-        alarmSound.stop();
+        // TODO: Create complex alarms object to check priority value instead
+        if (!currentAlarms.includes('High Peak Pressure')) {
+          alarmSound.stop();
+        }
       },
       titleStyle: { textAlign: textAlign, width: widthForBanner, fontSize: 20 },
       textStyle: { textAlign: textAlign, width: widthForBanner, fontSize: 16 },


### PR DESCRIPTION
Some alarms cannot have even their sound snoozed. One such is the `Peak Pressure` alarm. This change adds a quick check for the existence in current alarms to disallow even sound being snoozed for it. There is more work to be done, but that will be carried out in a separate refactor change.

Close #91 