### PR TITLE
Fix FIO2 Display on Monitoring Panel

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -63,11 +63,11 @@ export default function HomeScreen(props: any) {
         </View>
       </View>
       <View style={styles.configuredvalues}>
-        <MetricDisplayString
+        <MetricDisplay
           style={styles.configuredvaluedisplay}
           title={readingValues.fiO2.name}
           value={readingValues.fiO2.value}
-          unit={readingValues.fiO2.unit}></MetricDisplayString>
+          unit={readingValues.fiO2.unit}></MetricDisplay>
         <MetricDisplay
           style={styles.configuredvaluedisplay}
           title={readingValues.respiratoryRate.name}


### PR DESCRIPTION
We were using the `MetricDisplayString` component for it before since we had to show a range value like `x-y %`. Now that it used actual value, this could had a lot of decimal values which wasn't great to look at from the UI. Converting it to `MetricDisplay` allows us to show it to rounded number like the rest.