### PR TITLE
Fix app crash when switching to Alarms Panel in Pressure Modes

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -133,8 +133,8 @@ android {
         applicationId "com.openventpkventilatorapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 90
-        versionName "0.9.0"
+        versionCode 91
+        versionName "0.9.1"
     }
     splits {
         abi {

--- a/src/components/TidalVolumeMetricDisplay.tsx
+++ b/src/components/TidalVolumeMetricDisplay.tsx
@@ -3,14 +3,15 @@ import MetricDisplay from './MetricDisplay';
 
 export default function TidalVolumeMetricDisplay(props: any) {
   const { ventilationMode, parameter } = props;
+  let parameterValueToShow = parameter.setValue;
   if (ventilationMode === 'PCV' || ventilationMode === 'AC-PCV') {
-    parameter.setValue = null;
+    parameterValueToShow = null;
   }
 
   return (
     <MetricDisplay
       title={parameter.name}
-      value={parameter.setValue}
+      value={parameterValueToShow}
       unit={parameter.unit}
     />
   );

--- a/src/components/TidalVolumeMetricDisplay.tsx
+++ b/src/components/TidalVolumeMetricDisplay.tsx
@@ -3,15 +3,15 @@ import MetricDisplay from './MetricDisplay';
 
 export default function TidalVolumeMetricDisplay(props: any) {
   const { ventilationMode, parameter } = props;
-  let parameterValueToShow = parameter.setValue;
-  if (ventilationMode === 'PCV' || ventilationMode === 'AC-PCV') {
-    parameterValueToShow = null;
+
+  function isPressureControlledVentilationMode(): boolean {
+    return ventilationMode === 'PCV' || ventilationMode === 'AC-PCV';
   }
 
   return (
     <MetricDisplay
       title={parameter.name}
-      value={parameterValueToShow}
+      value={isPressureControlledVentilationMode() ? null : parameter.setValue}
       unit={parameter.unit}
     />
   );


### PR DESCRIPTION
The change to show a blank tidal volume set point in pressure mode ventilation mode in #89 was erroneously actually modifying the `setValue` field in the `setParameter` property passed down to it. This meant when we switch to the alarms panel, it would crash as the metric card component never expects a measured value to be `null` ever. This fix updates the code to not directly modify the property but instead pass the `null` forward to `MetricDisplay` in the `TidalVolumeMetricDisplay` and leave it unchanged. A little bit of refactoring was also carried out for escapsulation the ventilation mode check. Lastly, the version has been updated for this to be a patch fix.