### PR TITLE
Add version name to generated apks

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,7 +135,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 110
         versionName "0.11.0"
-        archivesBaseName = "$versionName"
+        archivesBaseName = "OpenVentPk-ventilator-app-$versionName"
     }
     splits {
         abi {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,6 +135,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 110
         versionName "0.11.0"
+        archivesBaseName = "$versionName"
     }
     splits {
         abi {
@@ -191,7 +192,6 @@ android {
                 output.versionCodeOverride =
                         versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
             }
-            variant.outputFile = file("$project.buildDir/${defaultConfig.versionName}.apk")
         }
     }
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -151,7 +151,7 @@ android {
             keyAlias 'androiddebugkey'
             keyPassword 'android'
         }
-	release {
+	      release {
             if (project.hasProperty('MYAPP_UPLOAD_STORE_FILE')) {
                 storeFile file(MYAPP_UPLOAD_STORE_FILE)
                 storePassword MYAPP_UPLOAD_STORE_PASSWORD
@@ -191,7 +191,7 @@ android {
                 output.versionCodeOverride =
                         versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
             }
-
+            variant.outputFile = file("$project.buildDir/${defaultConfig.versionName}.apk")
         }
     }
 }


### PR DESCRIPTION
Instead of having to rename the `app-debug.apk` or app-release.apk`, it's simpler to update the build settings to automatically append the version name to the apk name.