### PR TITLE
Create Release APK and attach to release on creation

### DIFF
--- a/.github/workflows/release-android-app.yml
+++ b/.github/workflows/release-android-app.yml
@@ -2,7 +2,7 @@ name: Create Android Release APK
 
 on:
   release:
-    - types: [published]
+    types: [published]
 
 jobs:
   build-android:

--- a/.github/workflows/release-android-app.yml
+++ b/.github/workflows/release-android-app.yml
@@ -1,8 +1,9 @@
 name: Create Android Release APK
 
+# Trigger the workflow on pull request activity
 on:
   release:
-    types: [published]
+    types: [published, created, edited]
 
 jobs:
   build-android:

--- a/.github/workflows/release-android-app.yml
+++ b/.github/workflows/release-android-app.yml
@@ -1,0 +1,39 @@
+name: Create Android Release APK
+
+on:
+  release:
+    - types: [published]
+
+jobs:
+  build-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Display commit message
+        run: |
+          git log --online -n 1 HEAD
+      - name: Install dependencies
+        run: |
+          yarn install
+      - name: Restore Release JKS
+        env:
+          RELEASE_KEYSTORE: ${{ secrets.RELEASE_KEYSTORE }}
+          RELEASE_KEYSTORE_PASSPHRASE: ${{ secrets.RELEASE_KEYSTORE_PASSPHRASE }}
+        run: |
+          echo "$RELEASE_KEYSTORE" > release.keystore.asc
+          gpg -d --passphrase "$RELEASE_KEYSTORE_PASSPHRASE" -- batch release.keystore.asc > ./android/app/release.keystore
+      - name: Grant permissions to gradlew
+        run: |
+          cd android && chmod +x ./gradlew
+      - name: Generate Android Release APK
+        env:
+          KEY_ALIAS: ${{ secrets.UPLOAD_STORE_KEY_ALIAS }}
+          STORE_PASSWORD: ${{ secrets.UPLOAD_STORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.UPLOAD_KEY_PASSWORD }}
+        run: |
+          cd android && ./gradlew assembleRelease -PMYAPP_UPLOAD_STORE_FILE="release.keystore" -PMYAPP_UPLOAD_KEY_ALIAS="$KEY_ALIAS" -PMYAPP_UPLOAD_STORE_PASSWORD="$STORE_PASSWORD" -PMYAPP_UPLOAD_KEY_PASSWORD="$KEY_PASSWORD"
+      - name: Upload release build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: app-release
+          path: android/app/build/outputs/apk/release/

--- a/.github/workflows/release-android-app.yml
+++ b/.github/workflows/release-android-app.yml
@@ -3,7 +3,7 @@ name: Create Android Release APK
 # Trigger the workflow on pull request activity
 on:
   release:
-    types: [published, created, edited]
+    types: [published]
 
 jobs:
   build-android:
@@ -22,7 +22,7 @@ jobs:
           RELEASE_KEYSTORE_PASSPHRASE: ${{ secrets.RELEASE_KEYSTORE_PASSPHRASE }}
         run: |
           echo "$RELEASE_KEYSTORE" > release.keystore.asc
-          gpg -d --passphrase "$RELEASE_KEYSTORE_PASSPHRASE" -- batch release.keystore.asc > ./android/app/release.keystore
+          gpg -d --passphrase "$RELEASE_KEYSTORE_PASSPHRASE" --batch release.keystore.asc > ./android/app/release.keystore
       - name: Grant permissions to gradlew
         run: |
           cd android && chmod +x ./gradlew

--- a/.github/workflows/release-android-app.yml
+++ b/.github/workflows/release-android-app.yml
@@ -39,10 +39,10 @@ jobs:
           name: app-release
           path: android/app/build/outputs/apk/release/
       - name: Get Release
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          id: get_release
-          uses: bruceadams/get-release@v1.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: get_release
+        uses: bruceadams/get-release@v1.2.0
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release-android-app.yml
+++ b/.github/workflows/release-android-app.yml
@@ -38,3 +38,19 @@ jobs:
         with:
           name: app-release
           path: android/app/build/outputs/apk/release/
+      - name: Get Release
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          id: get_release
+          uses: bruceadams/get-release@v1.2.0
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./android/app/build/outputs/apk/release/OpenVentPk-ventilator-app-${{ github.ref }}-release.apk
+          asset_name: OpenVentPk-ventilator-app-${{ github.ref }}-release.apk
+          asset_content_type: application/vnd.android.package-archive
+

--- a/.github/workflows/release-android-app.yml
+++ b/.github/workflows/release-android-app.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Display commit message
         run: |
-          git log --online -n 1 HEAD
+          git log --oneline -n 1 HEAD
       - name: Install dependencies
         run: |
           yarn install

--- a/.github/workflows/release-android-app.yml
+++ b/.github/workflows/release-android-app.yml
@@ -1,6 +1,5 @@
 name: Create Android Release APK
 
-# Trigger the workflow on pull request activity
 on:
   release:
     types: [published]
@@ -10,9 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Display commit message
-        run: |
-          git log --oneline -n 1 HEAD
       - name: Install dependencies
         run: |
           yarn install
@@ -49,7 +45,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: ./android/app/build/outputs/apk/release/OpenVentPk-ventilator-app-${{ github.event.release.tag_name }}-release.apk
           asset_name: OpenVentPk-ventilator-app-${{ github.event.release.tag_name }}-release.apk
           asset_content_type: application/vnd.android.package-archive

--- a/.github/workflows/release-android-app.yml
+++ b/.github/workflows/release-android-app.yml
@@ -50,7 +50,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./android/app/build/outputs/apk/release/OpenVentPk-ventilator-app-${{ github.ref }}-release.apk
-          asset_name: OpenVentPk-ventilator-app-${{ github.ref }}-release.apk
+          asset_path: ./android/app/build/outputs/apk/release/OpenVentPk-ventilator-app-${{ github.event.release.tag_name }}-release.apk
+          asset_name: OpenVentPk-ventilator-app-${{ github.event.release.tag_name }}-release.apk
           asset_content_type: application/vnd.android.package-archive
 

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ buck-out/
 \.buckd/
 *.keystore
 !debug.keystore
+*.asc
 
 # fastlane
 #


### PR DESCRIPTION
This change adds a workflow which allows building of a release apk for the application on published release and uploading the apk into the release itself. To do this, we make use of secret manager to inject secrets into the application to generate our key as well as the release apk.

Close #96 