### PR TITLE
Refactor SerialDataHandler

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,8 @@ import { log } from './logic/AppLogger';
 const Stack = createStackNavigator();
 
 export default function App() {
-  log.info('app');
+  log.info('Starting app');
+
   return (
     <View style={styles.container}>
       {Platform.OS === 'ios' && <StatusBar barStyle="default" />}

--- a/src/interfaces/SerialDataHandlerState.ts
+++ b/src/interfaces/SerialDataHandlerState.ts
@@ -1,0 +1,10 @@
+import { Devices } from 'react-native-serialport';
+
+export default interface SerialDataHandlerState {
+  serviceStarted: boolean;
+  connected: boolean;
+  usbAttached: boolean;
+  output: string;
+  outputArray: any[];
+  deviceList: Devices;
+}

--- a/src/logic/SerialDataHandler.ts
+++ b/src/logic/SerialDataHandler.ts
@@ -4,60 +4,93 @@ import {
   definitions,
   actions,
   ReturnedDataTypes,
+  IOnServiceStarted,
+  IOnError,
+  Devices,
 } from 'react-native-serialport';
 import DataConfig from '../constants/DataConfig';
 import { processSerialData } from './SerialParser';
 import { log } from './AppLogger';
-export default function SerialDataHandler(
-  serialParameters: any,
-  updateReadingStateFunction: (value: any) => void,
-) {
+import SerialDataHandlerState from '../interfaces/SerialDataHandlerState';
+
+function SerialDataHandler() {
   let SerialBuffer = new Array(0);
+  let updateReadingStateFunction: (value: any) => void;
 
   //to get values from two bytes
-  let state = {
+  let state: SerialDataHandlerState = {
     serviceStarted: false,
     connected: false,
     usbAttached: false,
     output: '',
     outputArray: [],
-    baudRate: serialParameters.baudRate,
+    deviceList: [],
+  };
+
+  const config = {
+    baudRate: 115200,
     interface: '-1',
     returnedDataType: <ReturnedDataTypes>(
       definitions.RETURNED_DATA_TYPES.INTARRAY
     ),
   };
 
-  function onServiceStarted(response: any) {
+  function onServiceStarted(response: IOnServiceStarted) {
     state.serviceStarted = true;
     if (response.deviceAttached) {
       onDeviceAttached();
     }
+    log.info('Service started');
   }
+
   function onServiceStopped() {
     state.serviceStarted = false;
+    log.info('Service stopped');
   }
+
   function onDeviceAttached() {
-    console.warn('Device attached');
     state.usbAttached = true;
+    log.info('Device attached');
+    fillDeviceList();
   }
+
+  function fillDeviceList() {
+    RNSerialport.getDeviceList()
+      .then((devices: Devices) => {
+        state.deviceList = devices;
+        log.info(`Devices: ${devices}`);
+      })
+      .catch((error: IOnError) => {
+        log.error(
+          `Failed to retrieve device list | ${error.errorCode} | ${error.errorMessage}`,
+        );
+      });
+  }
+
   function onDeviceDetached() {
     state.usbAttached = false;
+    log.info('Device detached');
   }
+
   function onConnected() {
     state.connected = true;
+    log.info('Connected');
   }
+
   function onDisconnected() {
     state.connected = false;
+    log.info('Disconnected');
   }
-  function onError(error: any) {
-    console.error(error);
+
+  function onError(error: IOnError) {
+    log.error(`An error occurred | ${error.errorCode} | ${error.errorMessage}`);
   }
 
   function onReadData(data: any) {
+    log.info(`Received data: ${data}`);
     let RemainingData = 0;
 
-        // var RNFS = require('react-native-fs');
+    // var RNFS = require('react-native-fs');
 
     // create a path you want to write to
     // :warning: on iOS, you cannot write into `RNFS.MainBundlePath`,
@@ -69,7 +102,7 @@ export default function SerialDataHandler(
     //   console.log(err.message);
     // });
 
-    if (state.returnedDataType === definitions.RETURNED_DATA_TYPES.INTARRAY) {
+    if (config.returnedDataType === definitions.RETURNED_DATA_TYPES.INTARRAY) {
       if (SerialBuffer.length > 0) {
         if (
           data.payload.length >=
@@ -114,7 +147,18 @@ export default function SerialDataHandler(
     }
   }
 
-  async function startUsbListener() {
+  function startUsbListener(parsedReadingsCallback: (value: any) => void) {
+    updateReadingStateFunction = parsedReadingsCallback;
+    addListeners();
+    RNSerialport.setReturnedDataType(config.returnedDataType);
+    RNSerialport.setAutoConnectBaudRate(config.baudRate);
+    RNSerialport.setInterface(parseInt(config.interface, 10));
+    RNSerialport.setAutoConnect(true);
+    RNSerialport.startUsbService();
+    log.info('Started usb service');
+  }
+
+  function addListeners(): void {
     DeviceEventEmitter.addListener(
       actions.ON_SERVICE_STARTED,
       onServiceStarted,
@@ -135,21 +179,17 @@ export default function SerialDataHandler(
     DeviceEventEmitter.addListener(actions.ON_CONNECTED, onConnected);
     DeviceEventEmitter.addListener(actions.ON_DISCONNECTED, onDisconnected);
     DeviceEventEmitter.addListener(actions.ON_READ_DATA, onReadData);
-    RNSerialport.setReturnedDataType(state.returnedDataType);
-    RNSerialport.setAutoConnectBaudRate(parseInt(state.baudRate, 10));
-    RNSerialport.setInterface(parseInt(state.interface, 10));
-    RNSerialport.setAutoConnect(true);
-    RNSerialport.startUsbService();
-    log.info('started usb service');
   }
 
   async function stopUsbListener() {
     DeviceEventEmitter.removeAllListeners();
-    const isOpen = RNSerialport.isOpen();
+    const isOpen = await RNSerialport.isOpen();
     if (isOpen) {
       RNSerialport.disconnect();
+      log.info('Disconnected from serial port');
     }
     RNSerialport.stopUsbService();
+    log.info('Stopped USB service');
   }
 
   return {
@@ -158,3 +198,5 @@ export default function SerialDataHandler(
     state,
   };
 }
+
+export default SerialDataHandler();

--- a/src/logic/useReading.tsx
+++ b/src/logic/useReading.tsx
@@ -4,6 +4,7 @@ import DummyDataGenerator from './DummyDataGenerator';
 import SerialDataHandler from './SerialDataHandler';
 import InitialReading from '../constants/InitialReading';
 import DataConfig from '../constants/DataConfig';
+import { log } from './AppLogger';
 
 const readingContext = createContext<any>(null);
 
@@ -28,25 +29,23 @@ export const useReading = () => {
 function useProvideReading() {
   const [reading, setReading] = useState(InitialReading);
   // const dummyGenerator = DummyDataGenerator(setReading, DataConfig.dataFrequency);
-  const serialDataHandler = SerialDataHandler({ baudRate: 115200 }, setReading);
 
   // Subscribe to user on mount
   // Because this sets state in the callback it will cause any ...
   // ... component that utilizes this hook to re-render with the ...
   // ... latest auth object.
   useEffect(() => {
-    serialDataHandler.startUsbListener();
-    console.log('starting generator');
+    log.info('Starting SerialDataHandler');
+    SerialDataHandler.startUsbListener(setReading);
+    // console.log('starting generator');
     // dummyGenerator.startGenerating();
     // Cleanup subscription on unmount
     return () => {
-      async function stopUSBListener() {
-        await serialDataHandler.stopUsbListener();
-      }
+      SerialDataHandler.stopUsbListener();
     };
     // return () => dummyGenerator.stopGenerating();
     // }, []);
-  }, [serialDataHandler.state.connected]);
+  }, []);
   // },[]);
   // Return the user object and auth methods
   return {


### PR DESCRIPTION
This change refactors the `SerialDataHander` module in a number of ways:
- It is a singleton class and instantiated once the first time it will be called. After that, it can have its exposed functions called
- Lots of logging added for different events of the component
- New function to log the devices attached in such an event
- Some updates to functions to remove unnecessary `async` types etc.
- Interface added for `SerialDataHandlerState`