### PR TITLE
Update package namespaces for app

### DIFF
--- a/android/.project
+++ b/android/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>openventpkVentilatorApp</name>
+	<name>OpenVentPkVentilatorApp</name>
 	<comment>Project android created by Buildship.</comment>
 	<projects>
 	</projects>

--- a/android/app/_BUCK
+++ b/android/app/_BUCK
@@ -35,12 +35,12 @@ android_library(
 
 android_build_config(
     name = "build_config",
-    package = "com.openventpkventilatorapp",
+    package = "com.openventpk.ventilatorapp",
 )
 
 android_resource(
     name = "res",
-    package = "com.openventpkventilatorapp",
+    package = "com.openventpk.ventilatorapp",
     res = "src/main/res",
 )
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -130,7 +130,7 @@ android {
     }
 
     defaultConfig {
-        applicationId "com.openventpkventilatorapp"
+        applicationId "com.openventpk.ventilatorapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 111

--- a/android/app/src/debug/java/com/openventpkventilatorapp/ReactNativeFlipper.java
+++ b/android/app/src/debug/java/com/openventpkventilatorapp/ReactNativeFlipper.java
@@ -4,7 +4,7 @@
  * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
  * directory of this source tree.
  */
-package com.openventpkventilatorapp;
+package com.openventpk.ventilatorapp;
 
 import android.content.Context;
 import com.facebook.flipper.android.AndroidFlipperClient;

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.openventpkventilatorapp">
+  package="com.openventpk.ventilatorapp">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/android/app/src/main/java/com/openventpkventilatorapp/MainActivity.java
+++ b/android/app/src/main/java/com/openventpkventilatorapp/MainActivity.java
@@ -1,4 +1,4 @@
-package com.openventpkventilatorapp;
+package com.openventpk.ventilatorapp;
 
 import com.facebook.react.ReactActivity;
 
@@ -10,6 +10,6 @@ public class MainActivity extends ReactActivity {
    */
   @Override
   protected String getMainComponentName() {
-    return "openventpkVentilatorApp";
+    return "OpenVentPkVentilatorApp";
   }
 }

--- a/android/app/src/main/java/com/openventpkventilatorapp/MainApplication.java
+++ b/android/app/src/main/java/com/openventpkventilatorapp/MainApplication.java
@@ -1,4 +1,4 @@
-package com.openventpkventilatorapp;
+package com.openventpk.ventilatorapp;
 
 import android.app.Application;
 import android.content.Context;
@@ -63,7 +63,7 @@ public class MainApplication extends Application implements ReactApplication {
          We use reflection here to pick up the class that initializes Flipper,
         since Flipper library is not available in release mode
         */
-        Class<?> aClass = Class.forName("com.openventpkventilatorapp.ReactNativeFlipper");
+        Class<?> aClass = Class.forName("com.openventpk.ventilatorapp.ReactNativeFlipper");
         aClass
             .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
             .invoke(null, context, reactInstanceManager);

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = 'openventpkVentilatorApp'
+rootProject.name = 'OpenVentPkVentilatorApp'
 include ':react-native-keep-awake'
 project(':react-native-keep-awake').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-keep-awake/android')
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)

--- a/app.json
+++ b/app.json
@@ -1,4 +1,4 @@
 {
-  "name": "openventpkVentilatorApp",
+  "name": "OpenVentPkVentilatorApp",
   "displayName": "OpenVentPk Ventilator App"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "openventpkVentilatorApp",
+  "name": "@openventpk/ventilator-app",
   "version": "0.0.1",
   "private": true,
   "scripts": {


### PR DESCRIPTION
This change updates the package names in the app to be more standardised, e.g. `com.openventpk.ventilatorapp` instead of `com.openventpkventilatorapp`