### PR TITLE
Clean up config ui related files

### DIFF
--- a/src/components/ConfigSelect/index.tsx
+++ b/src/components/ConfigSelect/index.tsx
@@ -9,6 +9,7 @@ import {
 } from '../Globals/ConfigMetric';
 
 interface ConfigSelectProps {
+  configKey: string;
   label: string;
   unit: string | undefined;
   pickerItems: Array<{
@@ -20,6 +21,7 @@ interface ConfigSelectProps {
 }
 
 const ConfigSelect = ({
+  configKey,
   label,
   unit,
   pickerItems,
@@ -37,7 +39,7 @@ const ConfigSelect = ({
           enabled={isEditable}
           selectedValue={selectedValue}
           style={{ height: 50, width: 150 }}
-          onValueChange={(itemValue) => settingsHandler(label, itemValue)}>
+          onValueChange={(itemValue) => settingsHandler(configKey, itemValue)}>
           {pickerItems.map((value) => (
             <Picker.Item
               key={`${value}`}

--- a/src/constants/Colors.ts
+++ b/src/constants/Colors.ts
@@ -29,5 +29,5 @@ export default {
   graphBarColor: 'grey',
   rootViewColor: '#fff',
   startVentilationButtonColor: 'green',
-  stopVentilationButton: '#e71837'
+  stopVentilationButton: '#e71837',
 };

--- a/src/constants/Configurables.ts
+++ b/src/constants/Configurables.ts
@@ -1,31 +1,41 @@
+import VentilationModes from './VentilationModes';
+
 export default {
-  'Ventilation Mode': {
-    options: ['PCV', 'VCV', 'AC-PCV', 'AC-VCV', 'CPAP'],
+  ventilationMode: {
+    label: 'Ventilation Mode',
+    options: VentilationModes,
   },
-  'I:E Ratio': {
-    options: ['1:1', '1:2']
+  ieRatio: {
+    label: 'I:E Ratio',
+    options: ['1:1', '1:2'],
   },
-  'Respiratory Rate': {
+  respiratoryRate: {
+    label: 'Respiratory Rate',
     unit: 'bpm',
-    options: [12, 16, 20]
+    options: [12, 16, 20],
   },
-  'Tidal Volume	': {
+  tidalVolume: {
+    label: 'Tidal Volume',
     unit: 'ml',
-    options: [200, 350, 450]
+    options: [200, 350, 450],
   },
-  'Pressure': {
+  pressure: {
+    label: 'Ventilation Mode',
     unit: 'cmH2O',
-    options: [15, 20, 25]
+    options: [15, 20, 25],
   },
-  'Flow Trigger': {
+  flowTrigger: {
+    label: 'Flow Trigger',
     unit: 'lpm',
-    options: [1, 3, 5]
+    options: [1, 3, 5],
   },
-  'PEEP': {
+  peep: {
+    label: 'PEEP',
     unit: 'cmH20',
-    options: [0, 5, 10, 15]
+    options: [0, 5, 10, 15],
   },
-  'FiO2': {
+  fiO2: {
+    label: 'FiO2',
     unit: '%',
     options: [
       '20 - 30',
@@ -35,7 +45,7 @@ export default {
       '60 - 70',
       '70 - 80',
       '80 - 90',
-      '90 - 100'	
-    ]
-  }
+      '90 - 100',
+    ],
+  },
 };

--- a/src/constants/FontSize.ts
+++ b/src/constants/FontSize.ts
@@ -1,5 +1,5 @@
 export default {
   connectionLabelText: '15px',
   iconSize: 50,
-  configurationLabelText: '15px'
+  configurationLabelText: '15px',
 };

--- a/src/constants/InitialVentilatorConfiguration.ts
+++ b/src/constants/InitialVentilatorConfiguration.ts
@@ -1,12 +1,12 @@
-const initalVentilatorConfiguration = {
-  'Ventilation Mode': 'PCV',
-  'I:E Ratio': '1:1',
-  'Respiratory Rate': 12,
-  'Tidal Volume': 200,
-  'Pressure': 15,
-  'Flow Trigger': 1,
-  'PEEP': 0,
-  'FiO2': '20 - 30',
-}
+const initialVentilatorConfiguration = {
+  ventilationMode: 'PCV',
+  ieRatio: '1:1',
+  respiratoryRate: 12,
+  tidalVolume: 200,
+  pressure: 15,
+  flowTrigger: 1,
+  peep: 0,
+  fiO2: '20 - 30',
+};
 
-export default initalVentilatorConfiguration;
+export default initialVentilatorConfiguration;

--- a/src/screens/ConfigurationScreen.tsx
+++ b/src/screens/ConfigurationScreen.tsx
@@ -6,11 +6,13 @@ import VentSwitch from '../components/VentSwitch';
 import ConfigSelect from '../components/ConfigSelect';
 import configs from '../constants/Configurables';
 import ToggleUpdate from '../components/UpdateButton';
-import initalVentilatorConfiguration from '../constants/InitialVentilatorConfiguration';
+import initialVentilatorConfiguration from '../constants/InitialVentilatorConfiguration';
 
 export default function LinksScreen() {
   const [canUpdate, setCanUpdate] = useState(false);
-  const [ventConfigs, setVentConfigs] = useState({...initalVentilatorConfiguration});
+  const [ventConfigs, setVentConfigs] = useState({
+    ...initialVentilatorConfiguration,
+  });
   const [isVentilating, setIsVentilating] = useState(false);
 
   const handleState = (key: string, value: string | boolean) => {
@@ -27,7 +29,8 @@ export default function LinksScreen() {
         {Object.keys(configs).map((config) => (
           <ConfigSelect
             key={config}
-            label={config}
+            configKey={config}
+            label={configs[config].label}
             selectedValue={ventConfigs[config]}
             isEditable={canUpdate}
             settingsHandler={handleState}
@@ -36,7 +39,10 @@ export default function LinksScreen() {
           />
         ))}
       </ScrollView>
-      <VentSwitch switchHandler={setIsVentilating} isVentilating={isVentilating} />
+      <VentSwitch
+        switchHandler={setIsVentilating}
+        isVentilating={isVentilating}
+      />
     </View>
   );
 }


### PR DESCRIPTION
This change makes a number of changes to the config ui related files for cleanup:
- Use proper keys for objects rather than string values
- Add new `configKey` property to store the key passed by the vent configs now
- Some whitespace and comma related changes added because of prettier
- Re-use ventilation modes in configurable options