### PR TITLE
Update logging with improvements and fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react-native-fs": "^2.16.6",
     "react-native-gesture-handler": "1.6.1",
     "react-native-keep-awake": "4.0.0",
-    "react-native-logs": "2.2.1",
+    "react-native-logs": "3.0.3",
     "react-native-reanimated": "1.8.0",
     "react-native-safe-area-context": "0.7.3",
     "react-native-screens": "2.7.0",

--- a/src/logic/AppLogger.ts
+++ b/src/logic/AppLogger.ts
@@ -1,7 +1,10 @@
 //config.js
-import { logger, configLoggerType } from 'react-native-logs';
-import { rnFsFileAsync } from 'react-native-logs/dist/transports/rnFsFileAsync';
-import { ansiColorConsoleSync } from 'react-native-logs/dist/transports/ansiColorConsoleSync';
+import {
+  logger,
+  configLoggerType,
+  consoleTransport,
+  fileAsyncTransport,
+} from 'react-native-logs';
 import * as RNFS from 'react-native-fs';
 import { getTimestampedFilename } from '../utils/FileUtils';
 import AppConfig from '../constants/AppConfig';
@@ -12,13 +15,16 @@ const logDirectory: string = `${AppConfig.internalAppDirectoryPath}/app-logs`;
 RNFS.mkdir(logDirectory);
 
 const config: configLoggerType = {
-  transport: (msg, level, options) => {
-    ansiColorConsoleSync(msg, level, options);
-    rnFsFileAsync(msg, level, {
-      loggerName: getTimestampedFilename(),
-      loggerPath: `${logDirectory}`,
-    });
+  transport: (props) => {
+    consoleTransport(props);
+    fileAsyncTransport(props);
   },
+  transportOptions: {
+    FS: RNFS,
+    logDirectory: `${logDirectory}`,
+    fileName: getTimestampedFilename(),
+  },
+  dateFormat: 'utc',
 };
 
 var log = logger.createLogger(config);

--- a/src/logic/SerialDataHandler.ts
+++ b/src/logic/SerialDataHandler.ts
@@ -58,7 +58,7 @@ function SerialDataHandler() {
     RNSerialport.getDeviceList()
       .then((devices: Devices) => {
         state.deviceList = devices;
-        log.info(`Devices: ${devices}`);
+        log.info(`Devices: ${JSON.stringify(devices)}`);
       })
       .catch((error: IOnError) => {
         log.error(
@@ -87,7 +87,7 @@ function SerialDataHandler() {
   }
 
   function onReadData(data: any) {
-    log.info(`Received data: ${data}`);
+    log.info(`Received payload: ${JSON.stringify(data.payload)}`);
     let RemainingData = 0;
 
     // var RNFS = require('react-native-fs');
@@ -139,6 +139,9 @@ function SerialDataHandler() {
               data.payload = [];
             }
           } else {
+            log.info(
+              'Did not find the header values - moving up one value in payload index',
+            );
             data.payload.splice(0, 1);
           }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5419,10 +5419,10 @@ react-native-keep-awake@4.0.0:
   resolved "https://registry.yarnpkg.com/react-native-keep-awake/-/react-native-keep-awake-4.0.0.tgz#d89fdc3fb60b3cffa979ef37dc5816196df998a2"
   integrity sha512-0Fotox+eLXQooeibVs3P60yASYUWjtRw9MZNmbuHt5UZQrgUrAKsE4jm7gTr4tPU1m1RkwGzcgUFpcOkh/ec7g==
 
-react-native-logs@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/react-native-logs/-/react-native-logs-2.2.1.tgz#ede856bae603957d6796e805e130a288e11b749d"
-  integrity sha512-yWS2sPy3ZksYBt9C6Ga7YkBWOFT3E/onLluyci42iv29MWcQim0i59vUmZgIFgg2NwC04IQi04xfK5GiSZvyrQ==
+react-native-logs@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/react-native-logs/-/react-native-logs-3.0.3.tgz#10bc6a24010dad2bcf9b3b7eacc27f6a3796ed01"
+  integrity sha512-Fnkoe9f1taxY8MiONGdPVaQPDml01i7oSYY+pxk/2fthJv24Z/Tlw22p8dgkuJ3SiwBHc71WlzQ4asKR5FPKbw==
 
 react-native-reanimated@1.8.0:
   version "1.8.0"


### PR DESCRIPTION
- Update the `react-native-logs` library to the latest version and its setup as it has breaking changes. The new logging will log as UTC
- Improve logging of object values with the help of `JSON.stringify()` so that we can glean important information
- Add extra logging for case when `$OVP` header is not matching