### PR TITLE
Move data packet parsing into separate function

### DIFF
--- a/src/interfaces/PacketReading.ts
+++ b/src/interfaces/PacketReading.ts
@@ -1,0 +1,20 @@
+import { BreathingPhase } from '../enums/BreathingPhase';
+import SetParameter from './SetParameter';
+
+export interface PacketReading {
+  measuredPressure: number;
+  peep: SetParameter;
+  pip: SetParameter;
+  plateauPressure: SetParameter;
+  respiratoryRate: SetParameter;
+  tidalVolume: SetParameter;
+  ieRatio: string;
+  vti: number;
+  vte: number;
+  minuteVentilation: SetParameter;
+  fiO2: SetParameter;
+  flowRate: number;
+  mode: string;
+  alarms: string[];
+  breathingPhase: BreathingPhase;
+}

--- a/src/logic/DataLogger.ts
+++ b/src/logic/DataLogger.ts
@@ -5,6 +5,7 @@ import DataConfig from '../constants/DataConfig';
 import { BreathingPhase } from '../enums/BreathingPhase';
 import { log } from './AppLogger';
 import { getTimestampedFilename, createDirectory } from '../utils/FileUtils';
+import { PacketReading } from '../interfaces/PacketReading';
 
 // TODO: Add serial data packets also
 export default function dataLogger() {
@@ -54,7 +55,7 @@ export default function dataLogger() {
     return Alarms.join(',');
   }
 
-  function onDataReading(reading: any) {
+  function onDataReading(reading: PacketReading) {
     const readingInCsv = getCsvFormat(reading);
     readingsCsv.push(readingInCsv);
   }
@@ -74,7 +75,7 @@ export default function dataLogger() {
     });
   }
 
-  function getCsvFormat(reading: any): string {
+  function getCsvFormat(reading: PacketReading): string {
     const {
       peep,
       measuredPressure,

--- a/src/logic/DataPacketParser.spec.tsx
+++ b/src/logic/DataPacketParser.spec.tsx
@@ -1,0 +1,77 @@
+import { BreathingPhase } from '../enums/BreathingPhase';
+import { PacketReading } from '../interfaces/PacketReading';
+import { parseDataPacket } from './DataPacketParser';
+
+test('verify packet parsing', () => {
+  // prettier-ignore
+  let testDataPacket: number[] = [36, 79, 86, 80, 136, 85, 9, 0, 50, 144, 143, 98, 250, 127, 198, 93, 55, 166, 0, 0, 88, 2, 60, 12, 33, 0, 30, 0, 50, 115, 111, 166, 132, 150, 0, 71, 42, 0, 209, 0, 195, 0, 0, 0, 0, 0, 0, 201, 13];
+  let expectedReading: PacketReading = {
+    measuredPressure: 4.650034332799272,
+    peep: {
+      name: 'PEEP',
+      unit: 'cmH2O',
+      setValue: 0,
+      value: 4.6523231860837715,
+      lowerLimit: 4,
+      upperLimit: 21,
+    },
+    pip: {
+      name: 'PIP',
+      unit: 'cmH2O',
+      setValue: 30,
+      value: -30,
+      lowerLimit: 25,
+      upperLimit: 35,
+    },
+    plateauPressure: {
+      name: 'Plateau Pressure',
+      unit: 'cmH2O',
+      setValue: 30,
+      value: 28.435797665369655,
+      lowerLimit: 28,
+      upperLimit: 32,
+    },
+    respiratoryRate: {
+      name: 'Patient Rate',
+      unit: 'BPM',
+      setValue: 12,
+      value: 0,
+      lowerLimit: 11,
+      upperLimit: 13,
+    },
+    tidalVolume: {
+      name: 'Tidal Volume',
+      unit: 'ml',
+      setValue: 600,
+      value: 253.0861371786068,
+      lowerLimit: 510,
+      upperLimit: 690,
+    },
+    ieRatio: '1.0 : 2.3',
+    vti: 600.5645838101777,
+    vte: 351.8425268940259,
+    minuteVentilation: {
+      name: 'Minute Vent.',
+      unit: 'lpm',
+      setValue: 7.199999999999999,
+      value: 11.093919279774166,
+      lowerLimit: 6,
+      upperLimit: 8,
+    },
+    fiO2: {
+      name: 'FiO2',
+      unit: '%',
+      setValue: 0,
+      setValueText: '0-0',
+      value: 0,
+      lowerLimit: -2,
+      upperLimit: 2,
+    },
+    flowRate: -0.03356984817273201,
+    mode: 'CPAP',
+    breathingPhase: BreathingPhase.Expiratory,
+    alarms: [],
+  };
+  const actualReading: PacketReading = parseDataPacket(testDataPacket);
+  expect(actualReading).toStrictEqual(expectedReading);
+});

--- a/src/logic/DataPacketParser.ts
+++ b/src/logic/DataPacketParser.ts
@@ -1,0 +1,167 @@
+import SetParameter from '../interfaces/SetParameter';
+import { getAlarmValues } from '../utils/SerialParsingHelpers';
+import { PacketReading } from '../interfaces/PacketReading';
+import VentilationModes from '../constants/VentilationModes';
+import { BreathingPhase } from '../enums/BreathingPhase';
+
+export function parseDataPacket(packet: number[]): PacketReading {
+  const setTidalVolume = getWordFloat(packet[20], packet[21], 1, 0);
+  const measuredTidalVolume = getWordFloat(
+    packet[8],
+    packet[9],
+    4000 / 65535,
+    -2000,
+  );
+
+  const tidalVolumeParameter: SetParameter = {
+    name: 'Tidal Volume',
+    unit: 'ml',
+    setValue: setTidalVolume,
+    value: measuredTidalVolume,
+    lowerLimit: Math.floor(setTidalVolume - 0.15 * setTidalVolume),
+    upperLimit: Math.ceil(setTidalVolume + 0.15 * setTidalVolume),
+  };
+
+  const measuredFlowRate = getWordFloat(
+    packet[12],
+    packet[13],
+    400 / 65535,
+    -200,
+  );
+
+  const measuredPressure = getWordFloat(
+    packet[10],
+    packet[11],
+    90 / 65535,
+    -30,
+  );
+  const breathingPhase = getBreathingPhase(packet[29]);
+
+  const setPeep = packet[26] - 30;
+  const measuredPeep = getWordFloat(packet[14], packet[15], 40 / 65535, -10);
+  const peepParameter: SetParameter = {
+    name: 'PEEP',
+    unit: 'cmH2O',
+    setValue: setPeep,
+    value: measuredPeep,
+    lowerLimit: 4,
+    upperLimit: 21,
+  };
+
+  const setInspiratoryPressure = packet[22] - 30;
+
+  const measuredPip = getWordFloat(packet[45], packet[46], 90 / 65535, -30);
+  const pipParameter: SetParameter = {
+    name: 'PIP',
+    unit: 'cmH2O',
+    setValue: setInspiratoryPressure,
+    value: measuredPip,
+    lowerLimit: setInspiratoryPressure - 5,
+    upperLimit: setInspiratoryPressure + 5,
+  };
+
+  const measuredPlateauPressure = getWordFloat(
+    packet[16],
+    packet[17],
+    90 / 65535,
+    -30,
+  );
+
+  const plateauPressureParameter: SetParameter = {
+    name: 'Plateau Pressure',
+    unit: 'cmH2O',
+    setValue: setInspiratoryPressure,
+    value: measuredPlateauPressure,
+    lowerLimit: setInspiratoryPressure - 2,
+    upperLimit: setInspiratoryPressure + 2,
+  };
+
+  const ventilationMode = getVentilationMode(packet[29]);
+
+  let currentAlarms = getAlarmValues(packet);
+
+  const setFiO2lowerBound = packet[25];
+  const setFiO2upperBound = packet[44];
+  const measuredFiO2 = getWordFloat(packet[18], packet[19], 100 / 65535, 0);
+  const fiO2Parameter: SetParameter = {
+    name: 'FiO2',
+    unit: '%',
+    setValue: setFiO2lowerBound,
+    setValueText: `${setFiO2lowerBound}-${setFiO2upperBound}`,
+    value: measuredFiO2,
+    lowerLimit: setFiO2lowerBound - 2,
+    upperLimit: setFiO2upperBound + 2,
+  };
+
+  const setRespiratoryRate = packet[23];
+  const measuredRespiratoryRate = packet[39];
+  const respiratoryRateParameter: SetParameter = {
+    name: 'Patient Rate',
+    unit: 'BPM',
+    setValue: setRespiratoryRate,
+    value: measuredRespiratoryRate,
+    lowerLimit: setRespiratoryRate - 1,
+    upperLimit: setRespiratoryRate + 1,
+  };
+
+  const setMinuteVentilation = (setTidalVolume / 1000) * setRespiratoryRate;
+  const measuredMinuteVentilation = getWordFloat(
+    packet[34],
+    packet[35],
+    40 / 65535,
+    0,
+  );
+  const minuteVentilationParameter: SetParameter = {
+    name: 'Minute Vent.',
+    unit: 'lpm',
+    setValue: setMinuteVentilation,
+    value: measuredMinuteVentilation,
+    lowerLimit: Math.floor(setMinuteVentilation - 0.1 * setMinuteVentilation),
+    upperLimit: Math.ceil(setMinuteVentilation + 0.1 * setMinuteVentilation),
+  };
+
+  const ieInhaledValue = '1.0';
+  const ieExhaleValue = packet[40] * (3 / 255);
+  const ieRatio = `${ieInhaledValue} : ${ieExhaleValue.toFixed(1)}`;
+
+  const reading: PacketReading = {
+    measuredPressure: measuredPressure,
+    peep: peepParameter,
+    pip: pipParameter,
+    plateauPressure: plateauPressureParameter,
+    respiratoryRate: respiratoryRateParameter,
+    tidalVolume: tidalVolumeParameter,
+    ieRatio: ieRatio,
+    vti: getWordFloat(packet[30], packet[31], 4000 / 65535, -2000),
+    vte: getWordFloat(packet[32], packet[33], 4000 / 65535, -2000),
+    minuteVentilation: minuteVentilationParameter,
+    fiO2: fiO2Parameter,
+    flowRate: measuredFlowRate,
+    mode: ventilationMode,
+    alarms: currentAlarms,
+    breathingPhase: breathingPhase,
+  };
+
+  return reading;
+}
+
+function getWordFloat(
+  ByteL: number,
+  ByteH: number,
+  multiplier: number,
+  offset: number,
+): number {
+  return (ByteL + ByteH * 256) * multiplier + offset;
+}
+
+function getVentilationMode(valueToParse: number): string {
+  // 0x1C is 00011100 so we find the values contain in bits 2-4
+  // we also want the index to retrieve the correct mode from our array
+  // so we shift the bits to the end to get the actual value
+  const ventilationModeIndex = (valueToParse & 0x1c) >> 2;
+  return VentilationModes[ventilationModeIndex];
+}
+
+function getBreathingPhase(valueToParse: number): BreathingPhase {
+  return valueToParse & 3;
+}

--- a/src/logic/SerialParser.tsx
+++ b/src/logic/SerialParser.tsx
@@ -273,8 +273,6 @@ function addGapToGraph(
   }
 }
 
-
-
 function getVentilationMode(valueToParse: number): string {
   // 0x1C is 00011100 so we find the values contain in bits 2-4
   // we also want the index to retrieve the correct mode from our array

--- a/src/logic/SerialParser.tsx
+++ b/src/logic/SerialParser.tsx
@@ -1,11 +1,9 @@
 import DataConfig from '../constants/DataConfig';
-import VentilationModes from '../constants/VentilationModes';
-import SetParameter from '../interfaces/SetParameter';
 import { BreathingPhase } from '../enums/BreathingPhase';
 import DataLogger from './DataLogger';
 import { log } from './AppLogger';
-import { getAlarmValues } from '../utils/SerialParsingHelpers';
 import { PacketReading } from '../interfaces/PacketReading';
+import { parseDataPacket } from './DataPacketParser';
 
 let pressureGraph = new Array(DataConfig.graphLength).fill(null);
 let volumeGraph = new Array(DataConfig.graphLength).fill(null);
@@ -77,147 +75,6 @@ export const processSerialData = (
   }
 };
 
-function parseDataPacket(packet: number[]): PacketReading {
-  const setTidalVolume = getWordFloat(packet[20], packet[21], 1, 0);
-  const measuredTidalVolume = getWordFloat(
-    packet[8],
-    packet[9],
-    4000 / 65535,
-    -2000,
-  );
-
-  const tidalVolumeParameter: SetParameter = {
-    name: 'Tidal Volume',
-    unit: 'ml',
-    setValue: setTidalVolume,
-    value: measuredTidalVolume,
-    lowerLimit: Math.floor(setTidalVolume - 0.15 * setTidalVolume),
-    upperLimit: Math.ceil(setTidalVolume + 0.15 * setTidalVolume),
-  };
-
-  const measuredFlowRate = getWordFloat(
-    packet[12],
-    packet[13],
-    400 / 65535,
-    -200,
-  );
-
-  const measuredPressure = getWordFloat(
-    packet[10],
-    packet[11],
-    90 / 65535,
-    -30,
-  );
-  const breathingPhase = getBreathingPhase(packet[29]);
-
-  const setPeep = packet[26] - 30;
-  const measuredPeep = getWordFloat(packet[14], packet[15], 40 / 65535, -10);
-  const peepParameter: SetParameter = {
-    name: 'PEEP',
-    unit: 'cmH2O',
-    setValue: setPeep,
-    value: measuredPeep,
-    lowerLimit: 4,
-    upperLimit: 21,
-  };
-
-  const setInspiratoryPressure = packet[22] - 30;
-
-  const measuredPip = getWordFloat(packet[45], packet[46], 90 / 65535, -30);
-  const pipParameter: SetParameter = {
-    name: 'PIP',
-    unit: 'cmH2O',
-    setValue: setInspiratoryPressure,
-    value: measuredPip,
-    lowerLimit: setInspiratoryPressure - 5,
-    upperLimit: setInspiratoryPressure + 5,
-  };
-
-  const measuredPlateauPressure = getWordFloat(
-    packet[16],
-    packet[17],
-    90 / 65535,
-    -30,
-  );
-
-  const plateauPressureParameter: SetParameter = {
-    name: 'Plateau Pressure',
-    unit: 'cmH2O',
-    setValue: setInspiratoryPressure,
-    value: measuredPlateauPressure,
-    lowerLimit: setInspiratoryPressure - 2,
-    upperLimit: setInspiratoryPressure + 2,
-  };
-
-  const ventilationMode = getVentilationMode(packet[29]);
-
-  let currentAlarms = getAlarmValues(packet);
-
-  const setFiO2lowerBound = packet[25];
-  const setFiO2upperBound = packet[44];
-  const measuredFiO2 = getWordFloat(packet[18], packet[19], 100 / 65535, 0);
-  const fiO2Parameter: SetParameter = {
-    name: 'FiO2',
-    unit: '%',
-    setValue: setFiO2lowerBound,
-    setValueText: `${setFiO2lowerBound}-${setFiO2upperBound}`,
-    value: measuredFiO2,
-    lowerLimit: setFiO2lowerBound - 2,
-    upperLimit: setFiO2upperBound + 2,
-  };
-
-  const setRespiratoryRate = packet[23];
-  const measuredRespiratoryRate = packet[39];
-  const respiratoryRateParameter: SetParameter = {
-    name: 'Patient Rate',
-    unit: 'BPM',
-    setValue: setRespiratoryRate,
-    value: measuredRespiratoryRate,
-    lowerLimit: setRespiratoryRate - 1,
-    upperLimit: setRespiratoryRate + 1,
-  };
-
-  const setMinuteVentilation = (setTidalVolume / 1000) * setRespiratoryRate;
-  const measuredMinuteVentilation = getWordFloat(
-    packet[34],
-    packet[35],
-    40 / 65535,
-    0,
-  );
-  const minuteVentilationParameter: SetParameter = {
-    name: 'Minute Vent.',
-    unit: 'lpm',
-    setValue: setMinuteVentilation,
-    value: measuredMinuteVentilation,
-    lowerLimit: Math.floor(setMinuteVentilation - 0.1 * setMinuteVentilation),
-    upperLimit: Math.ceil(setMinuteVentilation + 0.1 * setMinuteVentilation),
-  };
-
-  const ieInhaledValue = '1.0';
-  const ieExhaleValue = packet[40] * (3 / 255);
-  const ieRatio = `${ieInhaledValue} : ${ieExhaleValue.toFixed(1)}`;
-
-  const reading: PacketReading = {
-    measuredPressure: measuredPressure,
-    peep: peepParameter,
-    pip: pipParameter,
-    plateauPressure: plateauPressureParameter,
-    respiratoryRate: respiratoryRateParameter,
-    tidalVolume: tidalVolumeParameter,
-    ieRatio: ieRatio,
-    vti: getWordFloat(packet[30], packet[31], 4000 / 65535, -2000),
-    vte: getWordFloat(packet[32], packet[33], 4000 / 65535, -2000),
-    minuteVentilation: minuteVentilationParameter,
-    fiO2: fiO2Parameter,
-    flowRate: measuredFlowRate,
-    mode: ventilationMode,
-    alarms: currentAlarms,
-    breathingPhase: breathingPhase,
-  };
-
-  return reading;
-}
-
 function processIntegrityCheck(packet: any): boolean {
   if (packet.length > DataConfig.totalPacketLength) {
     return false;
@@ -235,15 +92,6 @@ function processIntegrityCheck(packet: any): boolean {
     log.error('crc failed ' + data);
   }
   return false;
-}
-
-function getWordFloat(
-  ByteL: number,
-  ByteH: number,
-  multiplier: number,
-  offset: number,
-): number {
-  return (ByteL + ByteH * 256) * multiplier + offset;
 }
 
 function addValueToGraph(
@@ -271,16 +119,4 @@ function addGapToGraph(
   ) {
     graph[i % DataConfig.graphLength] = null;
   }
-}
-
-function getVentilationMode(valueToParse: number): string {
-  // 0x1C is 00011100 so we find the values contain in bits 2-4
-  // we also want the index to retrieve the correct mode from our array
-  // so we shift the bits to the end to get the actual value
-  const ventilationModeIndex = (valueToParse & 0x1c) >> 2;
-  return VentilationModes[ventilationModeIndex];
-}
-
-function getBreathingPhase(valueToParse: number): BreathingPhase {
-  return valueToParse & 3;
 }

--- a/src/logic/SerialParser.tsx
+++ b/src/logic/SerialParser.tsx
@@ -5,6 +5,7 @@ import { BreathingPhase } from '../enums/BreathingPhase';
 import DataLogger from './DataLogger';
 import { log } from './AppLogger';
 import { getAlarmValues } from '../utils/SerialParsingHelpers';
+import { PacketReading } from '../interfaces/PacketReading';
 
 let pressureGraph = new Array(DataConfig.graphLength).fill(null);
 let volumeGraph = new Array(DataConfig.graphLength).fill(null);
@@ -25,40 +26,21 @@ export const processSerialData = (
   if (processIntegrityCheck(packet)) {
     interval++;
 
-    const setTidalVolume = getWordFloat(packet[20], packet[21], 1, 0);
-    const measuredTidalVolume = getWordFloat(
-      packet[8],
-      packet[9],
-      4000 / 65535,
-      -2000,
-    );
-    addValueToGraph(measuredTidalVolume, volumeGraph, counterForGraphs);
-    const tidalVolumeParameter: SetParameter = {
-      name: 'Tidal Volume',
-      unit: 'ml',
-      setValue: setTidalVolume,
-      value: measuredTidalVolume,
-      lowerLimit: Math.floor(setTidalVolume - 0.15 * setTidalVolume),
-      upperLimit: Math.ceil(setTidalVolume + 0.15 * setTidalVolume),
-    };
+    const packetReading: PacketReading = parseDataPacket(packet);
 
-    const measuredFlowRate = getWordFloat(
-      packet[12],
-      packet[13],
-      400 / 65535,
-      -200,
+    addValueToGraph(
+      packetReading.tidalVolume.value,
+      volumeGraph,
+      counterForGraphs,
     );
-    addValueToGraph(measuredFlowRate, flowRateGraph, counterForGraphs);
-
-    const measuredPressure = getWordFloat(
-      packet[10],
-      packet[11],
-      90 / 65535,
-      -30,
+    addValueToGraph(packetReading.flowRate, flowRateGraph, counterForGraphs);
+    addValueToGraph(
+      packetReading.measuredPressure,
+      pressureGraph,
+      counterForGraphs,
     );
-    addValueToGraph(measuredPressure, pressureGraph, counterForGraphs);
 
-    const breathingPhase = getBreathingPhase(packet[29]);
+    const breathingPhase = packetReading.breathingPhase;
     if (
       breathingPhase === BreathingPhase.Inspiratory &&
       previousBreath !== BreathingPhase.Inspiratory
@@ -75,117 +57,15 @@ export const processSerialData = (
     if (counterForGraphs >= DataConfig.graphLength) {
       counterForGraphs = 0;
     }
-
-    const setPeep = packet[26] - 30;
-    const measuredPeep = getWordFloat(packet[14], packet[15], 40 / 65535, -10);
-    const peepParameter: SetParameter = {
-      name: 'PEEP',
-      unit: 'cmH2O',
-      setValue: setPeep,
-      value: measuredPeep,
-      lowerLimit: 4,
-      upperLimit: 21,
-    };
-
-    const setInspiratoryPressure = packet[22] - 30;
-
-    const measuredPip = getWordFloat(packet[45], packet[46], 90 / 65535, -30);
-    const pipParameter: SetParameter = {
-      name: 'PIP',
-      unit: 'cmH2O',
-      setValue: setInspiratoryPressure,
-      value: measuredPip,
-      lowerLimit: setInspiratoryPressure - 5,
-      upperLimit: setInspiratoryPressure + 5,
-    };
-
-    const measuredPlateauPressure = getWordFloat(
-      packet[16],
-      packet[17],
-      90 / 65535,
-      -30,
-    );
-
-    const plateauPressureParameter: SetParameter = {
-      name: 'Plateau Pressure',
-      unit: 'cmH2O',
-      setValue: setInspiratoryPressure,
-      value: measuredPlateauPressure,
-      lowerLimit: setInspiratoryPressure - 2,
-      upperLimit: setInspiratoryPressure + 2,
-    };
-
-    const ventilationMode = getVentilationMode(packet[29]);
-
-    let currentAlarms = getAlarmValues(packet);
-
-    const setFiO2lowerBound = packet[25];
-    const setFiO2upperBound = packet[44];
-    const measuredFiO2 = getWordFloat(packet[18], packet[19], 100 / 65535, 0);
-    const fiO2Parameter: SetParameter = {
-      name: 'FiO2',
-      unit: '%',
-      setValue: setFiO2lowerBound,
-      setValueText: `${setFiO2lowerBound}-${setFiO2upperBound}`,
-      value: measuredFiO2,
-      lowerLimit: setFiO2lowerBound - 2,
-      upperLimit: setFiO2upperBound + 2,
-    };
-
-    const setRespiratoryRate = packet[23];
-    const measuredRespiratoryRate = packet[39];
-    const respiratoryRateParameter: SetParameter = {
-      name: 'Patient Rate',
-      unit: 'BPM',
-      setValue: setRespiratoryRate,
-      value: measuredRespiratoryRate,
-      lowerLimit: setRespiratoryRate - 1,
-      upperLimit: setRespiratoryRate + 1,
-    };
-
-    const setMinuteVentilation = (setTidalVolume / 1000) * setRespiratoryRate;
-    const measuredMinuteVentilation = getWordFloat(
-      packet[34],
-      packet[35],
-      40 / 65535,
-      0,
-    );
-    const minuteVentilationParameter: SetParameter = {
-      name: 'Minute Vent.',
-      unit: 'lpm',
-      setValue: setMinuteVentilation,
-      value: measuredMinuteVentilation,
-      lowerLimit: Math.floor(setMinuteVentilation - 0.1 * setMinuteVentilation),
-      upperLimit: Math.ceil(setMinuteVentilation + 0.1 * setMinuteVentilation),
-    };
-
-    const ieInhaledValue = '1.0';
-    const ieExhaleValue = packet[40] * (3 / 255);
-    const ieRatio = `${ieInhaledValue} : ${ieExhaleValue.toFixed(1)}`;
-
     const reading: any = {
-      measuredPressure: measuredPressure,
-      peep: peepParameter,
-      pip: pipParameter,
-      plateauPressure: plateauPressureParameter,
-      respiratoryRate: respiratoryRateParameter,
-      tidalVolume: tidalVolumeParameter,
-      ieRatio: ieRatio,
-      vti: getWordFloat(packet[30], packet[31], 4000 / 65535, -2000),
-      vte: getWordFloat(packet[32], packet[33], 4000 / 65535, -2000),
-      minuteVentilation: minuteVentilationParameter,
-      fiO2: fiO2Parameter,
-      flowRate: measuredFlowRate,
-      mode: ventilationMode,
+      ...packetReading,
       graphPressure: pressureGraph,
       graphVolume: volumeGraph,
       graphFlow: flowRateGraph,
       packetIntegrityRatio: `${failedPackets} / ${totalPackets}`,
-      alarms: currentAlarms,
-      breathingPhase: breathingPhase,
       breathMarkers: breathMarkers,
     };
-    dataLogger.onDataReading(reading);
+    dataLogger.onDataReading(packetReading);
 
     totalPackets++;
     if (interval > DataConfig.screenUpdateInterval) {
@@ -196,6 +76,147 @@ export const processSerialData = (
     failedPackets++;
   }
 };
+
+function parseDataPacket(packet: number[]): PacketReading {
+  const setTidalVolume = getWordFloat(packet[20], packet[21], 1, 0);
+  const measuredTidalVolume = getWordFloat(
+    packet[8],
+    packet[9],
+    4000 / 65535,
+    -2000,
+  );
+
+  const tidalVolumeParameter: SetParameter = {
+    name: 'Tidal Volume',
+    unit: 'ml',
+    setValue: setTidalVolume,
+    value: measuredTidalVolume,
+    lowerLimit: Math.floor(setTidalVolume - 0.15 * setTidalVolume),
+    upperLimit: Math.ceil(setTidalVolume + 0.15 * setTidalVolume),
+  };
+
+  const measuredFlowRate = getWordFloat(
+    packet[12],
+    packet[13],
+    400 / 65535,
+    -200,
+  );
+
+  const measuredPressure = getWordFloat(
+    packet[10],
+    packet[11],
+    90 / 65535,
+    -30,
+  );
+  const breathingPhase = getBreathingPhase(packet[29]);
+
+  const setPeep = packet[26] - 30;
+  const measuredPeep = getWordFloat(packet[14], packet[15], 40 / 65535, -10);
+  const peepParameter: SetParameter = {
+    name: 'PEEP',
+    unit: 'cmH2O',
+    setValue: setPeep,
+    value: measuredPeep,
+    lowerLimit: 4,
+    upperLimit: 21,
+  };
+
+  const setInspiratoryPressure = packet[22] - 30;
+
+  const measuredPip = getWordFloat(packet[45], packet[46], 90 / 65535, -30);
+  const pipParameter: SetParameter = {
+    name: 'PIP',
+    unit: 'cmH2O',
+    setValue: setInspiratoryPressure,
+    value: measuredPip,
+    lowerLimit: setInspiratoryPressure - 5,
+    upperLimit: setInspiratoryPressure + 5,
+  };
+
+  const measuredPlateauPressure = getWordFloat(
+    packet[16],
+    packet[17],
+    90 / 65535,
+    -30,
+  );
+
+  const plateauPressureParameter: SetParameter = {
+    name: 'Plateau Pressure',
+    unit: 'cmH2O',
+    setValue: setInspiratoryPressure,
+    value: measuredPlateauPressure,
+    lowerLimit: setInspiratoryPressure - 2,
+    upperLimit: setInspiratoryPressure + 2,
+  };
+
+  const ventilationMode = getVentilationMode(packet[29]);
+
+  let currentAlarms = getAlarmValues(packet);
+
+  const setFiO2lowerBound = packet[25];
+  const setFiO2upperBound = packet[44];
+  const measuredFiO2 = getWordFloat(packet[18], packet[19], 100 / 65535, 0);
+  const fiO2Parameter: SetParameter = {
+    name: 'FiO2',
+    unit: '%',
+    setValue: setFiO2lowerBound,
+    setValueText: `${setFiO2lowerBound}-${setFiO2upperBound}`,
+    value: measuredFiO2,
+    lowerLimit: setFiO2lowerBound - 2,
+    upperLimit: setFiO2upperBound + 2,
+  };
+
+  const setRespiratoryRate = packet[23];
+  const measuredRespiratoryRate = packet[39];
+  const respiratoryRateParameter: SetParameter = {
+    name: 'Patient Rate',
+    unit: 'BPM',
+    setValue: setRespiratoryRate,
+    value: measuredRespiratoryRate,
+    lowerLimit: setRespiratoryRate - 1,
+    upperLimit: setRespiratoryRate + 1,
+  };
+
+  const setMinuteVentilation = (setTidalVolume / 1000) * setRespiratoryRate;
+  const measuredMinuteVentilation = getWordFloat(
+    packet[34],
+    packet[35],
+    40 / 65535,
+    0,
+  );
+  const minuteVentilationParameter: SetParameter = {
+    name: 'Minute Vent.',
+    unit: 'lpm',
+    setValue: setMinuteVentilation,
+    value: measuredMinuteVentilation,
+    lowerLimit: Math.floor(setMinuteVentilation - 0.1 * setMinuteVentilation),
+    upperLimit: Math.ceil(setMinuteVentilation + 0.1 * setMinuteVentilation),
+  };
+
+  const ieInhaledValue = '1.0';
+  const ieExhaleValue = packet[40] * (3 / 255);
+  const ieRatio = `${ieInhaledValue} : ${ieExhaleValue.toFixed(1)}`;
+
+  const reading: PacketReading = {
+    measuredPressure: measuredPressure,
+    peep: peepParameter,
+    pip: pipParameter,
+    plateauPressure: plateauPressureParameter,
+    respiratoryRate: respiratoryRateParameter,
+    tidalVolume: tidalVolumeParameter,
+    ieRatio: ieRatio,
+    vti: getWordFloat(packet[30], packet[31], 4000 / 65535, -2000),
+    vte: getWordFloat(packet[32], packet[33], 4000 / 65535, -2000),
+    minuteVentilation: minuteVentilationParameter,
+    fiO2: fiO2Parameter,
+    flowRate: measuredFlowRate,
+    mode: ventilationMode,
+    alarms: currentAlarms,
+    breathingPhase: breathingPhase,
+  };
+
+  return reading;
+}
 
 function processIntegrityCheck(packet: any): boolean {
   if (packet.length > DataConfig.totalPacketLength) {


### PR DESCRIPTION
To ensure our logic for parsing a serial data packet is correct, the main logic of generating all the values into a `PacketReading` type object has been moved into a separate file which contains pure functions, such as parsing a data packet as well as converting values etc. To verify correctness, a unit test has been added.